### PR TITLE
[docker] Change the default storage location for Docker images and layers to the runner woker's volume.

### DIFF
--- a/releases/ubuntu22/arm64/images/ubuntu/scripts/build/install-docker.sh
+++ b/releases/ubuntu22/arm64/images/ubuntu/scripts/build/install-docker.sh
@@ -56,6 +56,10 @@ EOF
 # Reload systemd-tmpfiles to apply the new configuration
 systemd-tmpfiles --create /etc/tmpfiles.d/docker.conf
 
+
+# Change the default storage location for Docker images and layers to the runner woker's volume.
+echo '{"data-root": "/home/runner/_work/docker"}' | sudo tee /etc/docker/daemon.json > /dev/null
+
 # Enable docker.service
 systemctl is-active --quiet docker.service || systemctl start docker.service
 systemctl is-enabled --quiet docker.service || systemctl enable docker.service

--- a/releases/ubuntu22/x64/images/ubuntu/scripts/build/install-docker.sh
+++ b/releases/ubuntu22/x64/images/ubuntu/scripts/build/install-docker.sh
@@ -56,6 +56,9 @@ EOF
 # Reload systemd-tmpfiles to apply the new configuration
 systemd-tmpfiles --create /etc/tmpfiles.d/docker.conf
 
+# Change the default storage location for Docker images and layers to the runner woker's volume.
+echo '{"data-root": "/home/runner/_work/docker"}' | sudo tee /etc/docker/daemon.json > /dev/null
+
 # Enable docker.service
 systemctl is-active --quiet docker.service || systemctl start docker.service
 systemctl is-enabled --quiet docker.service || systemctl enable docker.service


### PR DESCRIPTION
# Context
When using a runner that contains an in stance storage, even the /home/runner/_work is mounted on the instance storage volume, the docker root volume is not mounted on the instance storage volume. This cause the job who uses docker build still using the root volume storage and runs out.

One workaround is changing /etc/docker/daemon.json in a step of the workflow. example provided as below
However, it would be great if runs-on can add it to the AMI.

```
2024-10-04T21:12:57.6990975Z /dev/nvme0n1p1  ext4       39G   14G   26G  34% /
2024-10-04T21:12:57.6994963Z /dev/md0        ext4      1.1T  796M  1.1T   1% /home/runner/_work
```
```
      - name: update docker data root
        run: |
          echo '{"data-root": "/home/runner/_work/docker"}' | sudo tee /etc/docker/daemon.json > /dev/null
          sudo systemctl restart docker
          sudo cat /etc/docker/daemon.json
```

https://github.com/runs-on/runner-images-for-aws/issues/9