### PR TITLE
Check the root mount, not hard-coded nvme partition

### DIFF
--- a/patches/ubuntu/files/after-reboot.sh
+++ b/patches/ubuntu/files/after-reboot.sh
@@ -1,7 +1,8 @@
  #!/bin/bash 
 set -ex
 
-tune2fs -c 0 /dev/nvme0n1p1
+# Check FS on next boot for the / mount
+tune2fs -c 0 $(cat /proc/self/mounts | grep " / " | cut -f 1 -d " ")
 
 rm -rf /var/lib/apt/lists
 rm -rf /var/lib/cloud/instances/*


### PR DESCRIPTION
I'm using another machine type, and the filesystem that should be checked isn't `/dev/nvme0n1p1` anymore.

On my desktop, `cat /proc/self/mounts | grep " / " | cut -f 1 -d " "` outputs `/dev/nvme0n1p2` because p1 is my /boot/efi. On my target machine, it's `/dev/sda1`