### PR TITLE
Enable GPU support on full images

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,7 @@ GEM
     unicode-display_width (2.5.0)
 
 PLATFORMS
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/bin/patch/ubuntu22-x64
+++ b/bin/patch/ubuntu22-x64
@@ -2,6 +2,10 @@
 
 set -eo pipefail
 
+gnu_sed() {
+  $(which gsed || which sed) "$@"
+}
+
 RELEASE_DIR="$1"
 
 if [ -z "$RELEASE_DIR" ]; then
@@ -14,6 +18,9 @@ build_dir="$release_dir/images/ubuntu/scripts/build"
 custom_dir="$release_dir/images/ubuntu/custom"
 toolsets_dir="$release_dir/images/ubuntu/toolsets"
 TOOLSET_PATH="$toolsets_dir/toolset-2204.json"
+
+# add gpu install script
+cp patches/ubuntu/build/install-gpu.sh "$release_dir/images/ubuntu/scripts/build/"
 
 # custom stuff
 mkdir -p $custom_dir
@@ -61,7 +68,7 @@ yq -oj -i 'del(.azureModules[])' $TOOLSET_PATH
 # Remove chromium since chrome already installed. 500MB saved
 # https://github.com/actions/runner-images/issues/2388
 # might need to add symlinks if causing issues, but let's see
-sed -i 's|# Download and unpack Chromium|invoke_tests "Browsers" "Chrome" && exit 0|' $release_dir/images/ubuntu/scripts/build/install-google-chrome.sh
+gnu_sed -i 's|# Download and unpack Chromium|invoke_tests "Browsers" "Chrome" && exit 0|' $release_dir/images/ubuntu/scripts/build/install-google-chrome.sh
 
 # finally, copy over the packer template
 cp patches/ubuntu/templates/ubuntu22-full-x64.pkr.hcl "$release_dir/images/ubuntu/templates/"

--- a/bin/patch/ubuntu24-x64
+++ b/bin/patch/ubuntu24-x64
@@ -2,6 +2,10 @@
 
 set -eo pipefail
 
+gnu_sed() {
+  $(which gsed || which sed) "$@"
+}
+
 RELEASE_DIR="$1"
 
 if [ -z "$RELEASE_DIR" ]; then
@@ -14,6 +18,9 @@ build_dir="$release_dir/images/ubuntu/scripts/build"
 custom_dir="$release_dir/images/ubuntu/custom"
 toolsets_dir="$release_dir/images/ubuntu/toolsets"
 TOOLSET_PATH="$toolsets_dir/toolset-2404.json"
+
+# add gpu install script
+cp patches/ubuntu/build/install-gpu.sh "$release_dir/images/ubuntu/scripts/build/"
 
 # custom stuff
 mkdir -p $custom_dir
@@ -61,7 +68,7 @@ yq -oj -i 'del(.azureModules[])' $TOOLSET_PATH
 # Remove chromium since chrome already installed. 500MB saved
 # https://github.com/actions/runner-images/issues/2388
 # might need to add symlinks if causing issues, but let's see
-sed -i 's|# Download and unpack Chromium|invoke_tests "Browsers" "Chrome" && exit 0|' $release_dir/images/ubuntu/scripts/build/install-google-chrome.sh
+gnu_sed -i 's|# Download and unpack Chromium|invoke_tests "Browsers" "Chrome" && exit 0|' $release_dir/images/ubuntu/scripts/build/install-google-chrome.sh
 
 # finally, copy over the packer template
 cp patches/ubuntu/templates/ubuntu24-full-x64.pkr.hcl "$release_dir/images/ubuntu/templates/"

--- a/patches/ubuntu/build/install-gpu.sh
+++ b/patches/ubuntu/build/install-gpu.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+set -eo pipefail
+
+# Source the helpers for use with the script
+source $HELPER_SCRIPTS/install.sh
+
+. /etc/os-release
+
+DIST_SLUG=""
+case $VERSION_CODENAME in
+    noble)
+        DIST_SLUG="ubuntu2404"
+        ;;
+    jammy)
+        DIST_SLUG="ubuntu2204"
+        ;;
+    *)
+        echo "Unsupported version codename: $VERSION_CODENAME"
+        exit 1
+        ;;
+esac
+
+# NVIDIA CUDA drivers
+DEBIAN_FILE="cuda-keyring_1.1-1_all.deb"
+REPO_URL="https://developer.download.nvidia.com/compute/cuda/repos/$DIST_SLUG/x86_64/$DEBIAN_FILE"
+GPG_KEY="/usr/share/keyrings/cuda-archive-keyring.gpg"
+
+wget $REPO_URL
+sudo dpkg -i $DEBIAN_FILE
+apt-get update
+
+package="cuda-drivers"
+version="latest"
+if [[ $version == "latest" ]]; then
+    apt-get install --no-install-recommends "$package"
+else
+    version_string=$(apt-cache madison "$package" | awk '{ print $3 }' | grep "$version" | head -1)
+    apt-get install --no-install-recommends "${package}=${version_string}"
+fi
+
+rm $DEBIAN_FILE
+rm $GPG_KEY
+
+# NVIDIA container toolkit
+REPO_URL="https://nvidia.github.io/libnvidia-container/stable/deb/\$(ARCH)"
+GPG_KEY="/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg"
+REPO_PATH="/etc/apt/sources.list.d/nvidia-container-toolkit.list"
+
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | gpg --dearmor -o $GPG_KEY
+echo "deb [signed-by=$GPG_KEY] $REPO_URL /" > $REPO_PATH
+apt-get update
+
+package="nvidia-container-toolkit"
+version="latest"
+if [[ $version == "latest" ]]; then
+    apt-get install --no-install-recommends "$package"
+else
+    version_string=$(apt-cache madison "$package" | awk '{ print $3 }' | grep "$version" | head -1)
+    apt-get install --no-install-recommends "${package}=${version_string}"
+fi
+
+# Configure the container runtime by using the nvidia-ctk command
+nvidia-ctk runtime configure --runtime=docker
+
+# Restart the Docker daemon
+systemctl restart docker
+docker info
+
+# Cleanup custom repositories
+rm $GPG_KEY
+rm $REPO_PATH

--- a/patches/ubuntu/templates/ubuntu22-full-x64.pkr.hcl
+++ b/patches/ubuntu/templates/ubuntu22-full-x64.pkr.hcl
@@ -371,6 +371,12 @@ build {
   }
 
   provisioner "shell" {
+    environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}"]
+    execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    scripts          = ["${path.root}/../scripts/build/install-gpu.sh"]
+  }
+
+  provisioner "shell" {
     execute_command     = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     scripts             = ["${path.root}/../custom/files/runner-user.sh"]
   }

--- a/patches/ubuntu/templates/ubuntu24-full-x64.pkr.hcl
+++ b/patches/ubuntu/templates/ubuntu24-full-x64.pkr.hcl
@@ -349,6 +349,12 @@ provisioner "shell" {
   }
 
   provisioner "shell" {
+    environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}"]
+    execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    scripts          = ["${path.root}/../scripts/build/install-gpu.sh"]
+  }
+
+  provisioner "shell" {
     execute_command     = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     scripts             = ["${path.root}/../custom/files/runner-user.sh"]
   }

--- a/releases/ubuntu22/x64/README.md
+++ b/releases/ubuntu22/x64/README.md
@@ -129,7 +129,8 @@ The `-latest` migration process is gradual and happens over 1-2 months in order 
 ### Package managers usage
 
 We use third-party package managers to install software during the image generation process. The table below lists the package managers and the software installed.
-> **Note**: third-party repositories are re-evaluated every year to identify if they are still useful and secure.
+> [!NOTE]
+> Third-party repositories are re-evaluated every year to identify if they are still useful and secure.
 
 | Operating system | Package manager                       | Third-party repos and packages |
 | :---             |        :---:                          |                           ---: |

--- a/releases/ubuntu22/x64/images/ubuntu/Ubuntu2204-Readme.md
+++ b/releases/ubuntu22/x64/images/ubuntu/Ubuntu2204-Readme.md
@@ -7,7 +7,7 @@
 # Ubuntu 22.04
 - OS Version: 22.04.5 LTS
 - Kernel Version: 6.5.0-1025-azure
-- Image Version: 20241215.1.0
+- Image Version: 20250105.1.0
 - Systemd version: 249.11-0ubuntu3.12
 
 ## Installed Software
@@ -32,16 +32,16 @@
 
 ### Package Management
 - cpan 1.64
-- Helm 3.16.3
-- Homebrew 4.4.11
-- Miniconda 24.9.2
+- Helm 3.16.4
+- Homebrew 4.4.14
+- Miniconda 24.11.1
 - Npm 10.8.2
 - NuGet 6.6.1.2
 - Pip 22.0.2
 - Pip3 22.0.2
 - Pipx 1.7.1
 - RubyGems 3.3.5
-- Vcpkg (build from commit b545373a9)
+- Vcpkg (build from commit 65be70199)
 - Yarn 1.22.22
 
 #### Environment variables
@@ -60,10 +60,10 @@ to accomplish this.
 
 ### Project Management
 - Ant 1.10.12
-- Gradle 8.11.1
+- Gradle 8.12
 - Lerna 8.1.9
 - Maven 3.8.8
-- Sbt 1.10.6
+- Sbt 1.10.7
 
 ### Tools
 - Ansible 2.17.7
@@ -73,11 +73,11 @@ to accomplish this.
 - Bazelisk 1.25.0
 - Bicep 0.32.4
 - Buildah 1.23.1
-- CMake 3.31.2
+- CMake 3.31.3
 - CodeQL Action Bundle 2.20.0
 - Docker Amazon ECR Credential Helper 0.9.0
 - Docker Compose v2 2.27.1
-- Docker-Buildx 0.19.2
+- Docker-Buildx 0.19.3
 - Docker Client 26.1.3
 - Docker Server 26.1.3
 - Fastlane 2.226.0
@@ -87,7 +87,7 @@ to accomplish this.
 - Haveged 1.9.14
 - Heroku 10.0.0
 - jq 1.6
-- Kind 0.25.0
+- Kind 0.26.0
 - Kubectl 1.32.0
 - Kustomize 5.5.0
 - Leiningen 2.11.2
@@ -99,31 +99,31 @@ to accomplish this.
 - nvm 0.40.1
 - OpenSSL 3.0.2-0ubuntu1.18
 - Packer 1.11.2
-- Parcel 2.13.2
+- Parcel 2.13.3
 - Podman 3.4.4
-- Pulumi 3.143.0
+- Pulumi 3.144.1
 - R 4.4.2
 - Skopeo 1.4.1
 - Sphinx Open Source Search Server 2.2.11
 - SVN 1.14.1
-- Terraform 1.10.2
+- Terraform 1.10.3
 - yamllint 1.35.1
 - yq 4.44.6
 - zstd 1.5.6
 
 ### CLI Tools
-- Alibaba Cloud CLI 3.0.237
-- AWS CLI 2.22.17
+- Alibaba Cloud CLI 3.0.244
+- AWS CLI 2.22.28
 - AWS CLI Session Manager Plugin 1.2.694.0
 - AWS SAM CLI 1.132.0
 - Azure CLI 2.67.0
 - Azure CLI (azure-devops) 1.0.1
-- GitHub CLI 2.63.2
-- Google Cloud CLI 503.0.0
-- Netlify CLI 17.38.0
-- OpenShift CLI 4.17.8
-- ORAS CLI 1.2.1
-- Vercel CLI 39.2.2
+- GitHub CLI 2.64.0
+- Google Cloud CLI 504.0.1
+- Netlify CLI 17.38.1
+- OpenShift CLI 4.17.10
+- ORAS CLI 1.2.2
+- Vercel CLI 39.2.5
 
 ### Java
 | Version             | Environment Variable |
@@ -142,10 +142,10 @@ Both Xdebug and PCOV extensions are installed, but only Xdebug is enabled.
 ```
 
 ### Haskell Tools
-- Cabal 3.12.1.0
-- GHC 9.10.1
-- GHCup 0.1.30.0
-- Stack 3.1.1
+- Cabal 3.14.1.1
+- GHC 9.12.1
+- GHCup 0.1.40.0
+- Stack 3.3.1
 
 ### Rust Tools
 - Cargo 1.83.0
@@ -162,13 +162,13 @@ Both Xdebug and PCOV extensions are installed, but only Xdebug is enabled.
 - Rustfmt 1.8.0
 
 ### Browsers and Drivers
-- Google Chrome 131.0.6778.139
-- ChromeDriver 131.0.6778.108
+- Google Chrome 131.0.6778.204
+- ChromeDriver 131.0.6778.204
 - Chromium 131.0.6778.0
-- Microsoft Edge 131.0.2903.99
-- Microsoft Edge WebDriver 131.0.2903.87
+- Microsoft Edge 131.0.2903.112
+- Microsoft Edge WebDriver 131.0.2903.112
 - Selenium server 4.27.0
-- Mozilla Firefox 133.0
+- Mozilla Firefox 133.0.3
 - Geckodriver 0.35.0
 
 #### Environment variables
@@ -220,10 +220,9 @@ Use the following command as a part of your job to start the service: 'sudo syst
 - 22.12.0
 
 #### Python
-- 3.7.17
 - 3.8.18
-- 3.9.20
-- 3.10.15
+- 3.9.21
+- 3.10.16
 - 3.11.11
 - 3.12.8
 
@@ -258,7 +257,7 @@ Use the following command as a part of your job to start the service: 'sudo syst
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Android Command Line Tools | 9.0                                                                                                                                                                                                                                                                                                         |
 | Android SDK Build-tools    | 35.0.0<br>34.0.0<br>33.0.0 33.0.1 33.0.2 33.0.3<br>32.0.0<br>31.0.0                                                                                                                                                                                                                                         |
-| Android SDK Platforms      | android-35-ext14 (rev 1)<br>android-35 (rev 1)<br>android-34-ext8 (rev 1)<br>android-34-ext12 (rev 1)<br>android-34-ext11 (rev 1)<br>android-34-ext10 (rev 1)<br>android-34 (rev 3)<br>android-33-ext5 (rev 1)<br>android-33-ext4 (rev 1)<br>android-33 (rev 3)<br>android-32 (rev 1)<br>android-31 (rev 1) |
+| Android SDK Platforms      | android-35-ext14 (rev 1)<br>android-35 (rev 2)<br>android-34-ext8 (rev 1)<br>android-34-ext12 (rev 1)<br>android-34-ext11 (rev 1)<br>android-34-ext10 (rev 1)<br>android-34 (rev 3)<br>android-33-ext5 (rev 1)<br>android-33-ext4 (rev 1)<br>android-33 (rev 3)<br>android-32 (rev 1)<br>android-31 (rev 1) |
 | Android Support Repository | 47.0.0                                                                                                                                                                                                                                                                                                      |
 | CMake                      | 3.10.2<br>3.18.1<br>3.22.1                                                                                                                                                                                                                                                                                  |
 | Google Play services       | 49                                                                                                                                                                                                                                                                                                          |
@@ -283,13 +282,13 @@ Use the following command as a part of your job to start the service: 'sudo syst
 | alpine:3.18          | sha256:2995c82e8e723d9a5c8585cb8e901d1c50e3c2759031027d3bff577449435157  | 2024-09-06 |
 | alpine:3.19          | sha256:7a85bf5dc56c949be827f84f9185161265c58f589bb8b2a6b6bb6d3076c1be21  | 2024-09-06 |
 | debian:10            | sha256:58ce6f1271ae1c8a2006ff7d3e54e9874d839f573d8009c20154ad0f2fb0a225  | 2024-06-13 |
-| debian:11            | sha256:e91d1b0684e0f26a29c2353c52d4814f4d153e10b1faddf9fbde473ed71e2fcf  | 2024-12-02 |
-| moby/buildkit:latest | sha256:58e6d150a3c5a4b92e99ea8df2cbe976ad6d2ae5beab39214e84fada05b059d5  | 2024-12-04 |
-| node:18              | sha256:b57ae84fe7880a23b389f8260d726b784010ed470c2ee26d4e2cbdb955d25b12  | 2024-11-15 |
+| debian:11            | sha256:21b74d95871e8676a0cf47df9caebb1021b2af60b9a6e4777ce92f92f98e3a90  | 2024-12-23 |
+| moby/buildkit:latest | sha256:86c0ad9d1137c186e9d455912167df20e530bdf7f7c19de802e892bb8ca16552  | 2024-12-16 |
+| node:18              | sha256:7f31a1eb14c61719b8bb0eaa029310cc33851f71d3578cc422b390f8096977c5  | 2024-11-15 |
 | node:18-alpine       | sha256:6eb9c3d9bd191bd2cc6ce7ec3d5ec4c2127616140c8586af96a6bec8f28689d1  | 2024-12-05 |
-| node:20              | sha256:f4755c9039bdeec5c736b2e0dd5b47700d6393b65688b9e9f807ec12f54a8690  | 2024-11-20 |
+| node:20              | sha256:d17aaa2a2fd82e09bd6a6da7cc4a79741340d2a3e39d172d1b30f295b1a850ff  | 2024-11-20 |
 | node:20-alpine       | sha256:426f843809ae05f324883afceebaa2b9cab9cb697097dbb1a2a7a41c5701de72  | 2024-12-05 |
-| node:22              | sha256:35a5dd72bcac4bce43266408b58a02be6ff0b6098ffa6f5435aeea980a8951d7  | 2024-12-03 |
+| node:22              | sha256:0e910f435308c36ea60b4cfd7b80208044d77a074d16b768a81901ce938a62dc  | 2024-12-03 |
 | node:22-alpine       | sha256:6e80991f69cc7722c561e5d14d5e72ab47c0d6b6cfb3ae50fb9cf9a7b30fdf97  | 2024-12-05 |
 | ubuntu:20.04         | sha256:8e5c4f0285ecbb4ead070431d29b576a530d3166df73ec44affc1cd27555141b  | 2024-10-11 |
 | ubuntu:22.04         | sha256:0e5e4a57c2499249aafc3b40fcd541e9a456aab7296681a3994d631587203f97  | 2024-09-11 |
@@ -306,7 +305,7 @@ Use the following command as a part of your job to start the service: 'sudo syst
 | brotli                 | 1.0.9-2build6                       |
 | bzip2                  | 1.0.8-5build1                       |
 | coreutils              | 8.32-4.1ubuntu1.2                   |
-| curl                   | 7.81.0-1ubuntu1.19                  |
+| curl                   | 7.81.0-1ubuntu1.20                  |
 | dbus                   | 1.12.20-2ubuntu4.1                  |
 | dnsutils               | 1:9.18.28-0ubuntu0.22.04.1          |
 | dpkg                   | 1.21.1ubuntu2.3                     |
@@ -329,7 +328,7 @@ Use the following command as a part of your job to start the service: 'sudo syst
 | libc++-dev             | 1:14.0-55\~exp2                     |
 | libc++abi-dev          | 1:14.0-55\~exp2                     |
 | libc6-dev              | 2.35-0ubuntu3.8                     |
-| libcurl4               | 7.81.0-1ubuntu1.19                  |
+| libcurl4               | 7.81.0-1ubuntu1.20                  |
 | libgbm-dev             | 23.2.1-1ubuntu3.1\~22.04.3          |
 | libgconf-2-4           | 3.2.6-7ubuntu2                      |
 | libgsl-dev             | 2.7.1+dfsg-3                        |

--- a/releases/ubuntu22/x64/images/ubuntu/Ubuntu2404-Readme.md
+++ b/releases/ubuntu22/x64/images/ubuntu/Ubuntu2404-Readme.md
@@ -7,7 +7,7 @@
 # Ubuntu 24.04
 - OS Version: 24.04.1 LTS
 - Kernel Version: 6.8.0-1017-azure
-- Image Version: 20241215.1.0
+- Image Version: 20250105.1.0
 - Systemd version: 255.4-1ubuntu8.4
 
 ## Installed Software
@@ -30,15 +30,15 @@
 
 ### Package Management
 - cpan 1.64
-- Helm 3.16.3
-- Homebrew 4.4.11
-- Miniconda 24.9.2
+- Helm 3.16.4
+- Homebrew 4.4.14
+- Miniconda 24.11.1
 - Npm 10.8.2
 - Pip 24.0
 - Pip3 24.0
 - Pipx 1.7.1
 - RubyGems 3.4.20
-- Vcpkg (build from commit b545373a9)
+- Vcpkg (build from commit 65be70199)
 - Yarn 1.22.22
 
 #### Environment variables
@@ -57,7 +57,7 @@ to accomplish this.
 
 ### Project Management
 - Ant 1.10.14
-- Gradle 8.11.1
+- Gradle 8.12
 - Lerna 8.1.9
 - Maven 3.8.8
 
@@ -68,11 +68,11 @@ to accomplish this.
 - Bazelisk 1.25.0
 - Bicep 0.32.4
 - Buildah 1.33.7
-- CMake 3.31.2
+- CMake 3.31.3
 - CodeQL Action Bundle 2.20.0
 - Docker Amazon ECR Credential Helper 0.9.0
 - Docker Compose v2 2.27.1
-- Docker-Buildx 0.19.2
+- Docker-Buildx 0.19.3
 - Docker Client 26.1.3
 - Docker Server 26.1.3
 - Fastlane 2.226.0
@@ -81,7 +81,7 @@ to accomplish this.
 - Git-ftp 1.6.0
 - Haveged 1.9.14
 - jq 1.7
-- Kind 0.25.0
+- Kind 0.26.0
 - Kubectl 1.32.0
 - Kustomize 5.5.0
 - MediaInfo 24.01
@@ -92,9 +92,9 @@ to accomplish this.
 - nvm 0.40.1
 - OpenSSL 3.0.13-0ubuntu3.4
 - Packer 1.11.2
-- Parcel 2.13.2
+- Parcel 2.13.3
 - Podman 4.9.3
-- Pulumi 3.143.0
+- Pulumi 3.144.1
 - Skopeo 1.13.3
 - Sphinx Open Source Search Server 2.2.11
 - yamllint 1.35.1
@@ -102,13 +102,13 @@ to accomplish this.
 - zstd 1.5.6
 
 ### CLI Tools
-- AWS CLI 2.22.17
+- AWS CLI 2.22.28
 - AWS CLI Session Manager Plugin 1.2.694.0
 - AWS SAM CLI 1.132.0
 - Azure CLI 2.67.0
 - Azure CLI (azure-devops) 1.0.1
-- GitHub CLI 2.63.2
-- Google Cloud CLI 503.0.0
+- GitHub CLI 2.64.0
+- Google Cloud CLI 504.0.1
 
 ### Java
 | Version              | Environment Variable |
@@ -127,10 +127,10 @@ Both Xdebug and PCOV extensions are installed, but only Xdebug is enabled.
 ```
 
 ### Haskell Tools
-- Cabal 3.12.1.0
-- GHC 9.10.1
-- GHCup 0.1.30.0
-- Stack 3.1.1
+- Cabal 3.14.1.1
+- GHC 9.12.1
+- GHCup 0.1.40.0
+- Stack 3.3.1
 
 ### Rust Tools
 - Cargo 1.83.0
@@ -142,13 +142,13 @@ Both Xdebug and PCOV extensions are installed, but only Xdebug is enabled.
 - Rustfmt 1.8.0
 
 ### Browsers and Drivers
-- Google Chrome 131.0.6778.139
-- ChromeDriver 131.0.6778.108
+- Google Chrome 131.0.6778.204
+- ChromeDriver 131.0.6778.204
 - Chromium 131.0.6778.0
-- Microsoft Edge 131.0.2903.99
-- Microsoft Edge WebDriver 131.0.2903.87
+- Microsoft Edge 131.0.2903.112
+- Microsoft Edge WebDriver 131.0.2903.112
 - Selenium server 4.27.0
-- Mozilla Firefox 133.0
+- Mozilla Firefox 133.0.3
 - Geckodriver 0.35.0
 
 #### Environment variables
@@ -196,8 +196,8 @@ Use the following command as a part of your job to start the service: 'sudo syst
 - 22.12.0
 
 #### Python
-- 3.9.20
-- 3.10.15
+- 3.9.21
+- 3.10.16
 - 3.11.11
 - 3.12.8
 
@@ -225,7 +225,7 @@ Use the following command as a part of your job to start the service: 'sudo syst
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Android Command Line Tools | 12.0                                                                                                                                                                                                                                      |
 | Android SDK Build-tools    | 35.0.0<br>34.0.0                                                                                                                                                                                                                          |
-| Android SDK Platforms      | android-35-ext14 (rev 1)<br>android-35 (rev 1)<br>android-34-ext8 (rev 1)<br>android-34-ext12 (rev 1)<br>android-34-ext11 (rev 1)<br>android-34-ext10 (rev 1)<br>android-34 (rev 3)<br>android-33-ext5 (rev 1)<br>android-33-ext4 (rev 1) |
+| Android SDK Platforms      | android-35-ext14 (rev 1)<br>android-35 (rev 2)<br>android-34-ext8 (rev 1)<br>android-34-ext12 (rev 1)<br>android-34-ext11 (rev 1)<br>android-34-ext10 (rev 1)<br>android-34 (rev 3)<br>android-33-ext5 (rev 1)<br>android-33-ext4 (rev 1) |
 | Android Support Repository | 47.0.0                                                                                                                                                                                                                                    |
 | Google Play services       | 49                                                                                                                                                                                                                                        |
 | Google Repository          | 58                                                                                                                                                                                                                                        |
@@ -253,7 +253,7 @@ Use the following command as a part of your job to start the service: 'sudo syst
 | brotli                 | 1.1.0-2build2               |
 | bzip2                  | 1.0.8-5.1build0.1           |
 | coreutils              | 9.4-3ubuntu6                |
-| curl                   | 8.5.0-2ubuntu10.5           |
+| curl                   | 8.5.0-2ubuntu10.6           |
 | dbus                   | 1.14.10-4ubuntu4.1          |
 | dnsutils               | 1:9.18.28-0ubuntu0.24.04.1  |
 | dpkg                   | 1.22.6ubuntu6.1             |

--- a/releases/ubuntu22/x64/images/ubuntu/scripts/build/cleanup.sh
+++ b/releases/ubuntu22/x64/images/ubuntu/scripts/build/cleanup.sh
@@ -19,6 +19,13 @@ if command -v journalctl; then
     journalctl --vacuum-time=1s
 fi
 
+# remove redundant folders from azcli
+if [[ -z "${AZURE_CONFIG_DIR}" ]]; then
+    rm -rf $AZURE_CONFIG_DIR/logs
+    rm -rf $AZURE_CONFIG_DIR/commands
+    rm -rf $AZURE_CONFIG_DIR/telemetry
+fi
+
 # delete all .gz and rotated file
 find /var/log -type f -regex ".*\.gz$" -delete
 find /var/log -type f -regex ".*\.[0-9]$" -delete

--- a/releases/ubuntu22/x64/images/ubuntu/scripts/build/install-azure-cli.sh
+++ b/releases/ubuntu22/x64/images/ubuntu/scripts/build/install-azure-cli.sh
@@ -4,12 +4,40 @@
 ##  Desc:  Install Azure CLI (az)
 ################################################################################
 
+# Source the helpers for use with the script
+source $HELPER_SCRIPTS/etc-environment.sh
+
+# AZURE_CONFIG_DIR shell variable defines where the CLI configuration file for managing behavior are stored
+# https://learn.microsoft.com/en-us/cli/azure/azure-cli-configuration#cli-configuration-file
+# This path SHOULD be different from the installation directory /opt/az/
+export AZURE_CONFIG_DIR="/opt/az-config"
+mkdir -p $AZURE_CONFIG_DIR
+set_etc_environment_variable "AZURE_CONFIG_DIR" "${AZURE_CONFIG_DIR}"
+
+# AZURE_EXTENSION_DIR shell variable defines where modules are installed
+# https://docs.microsoft.com/en-us/cli/azure/azure-cli-extensions-overview
+# This path SHOULD be different from the installation directory /opt/az/
+export AZURE_EXTENSION_DIR="/opt/az-extension"
+mkdir -p $AZURE_EXTENSION_DIR
+set_etc_environment_variable "AZURE_EXTENSION_DIR" "${AZURE_EXTENSION_DIR}"
+
 # Install Azure CLI (instructions taken from https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
 curl -fsSL https://aka.ms/InstallAzureCLIDeb | sudo bash
 
 echo "azure-cli https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt" >> $HELPER_SCRIPTS/apt-sources.txt
 
-rm -f /etc/apt/sources.list.d/azure-cli.list
-rm -f /etc/apt/sources.list.d/azure-cli.list.save
+# Remove Azure CLI repository (instructions taken from https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt#uninstall-azure-cli)
+rm -f /etc/apt/sources.list.d/azure-cli.sources
+
+echo "Warmup 'az'"
+az --help > /dev/null
+if [ $? -ne 0 ]; then
+    echo "Command 'az --help' failed"
+    exit 1
+fi
+
+# Hand over the ownership of the directories and files to the non-root user
+chown -R "$SUDO_USER:$SUDO_USER" $AZURE_CONFIG_DIR
+chown -R "$SUDO_USER:$SUDO_USER" $AZURE_EXTENSION_DIR
 
 invoke_tests "CLI.Tools" "Azure CLI"

--- a/releases/ubuntu22/x64/images/ubuntu/scripts/build/install-azure-devops-cli.sh
+++ b/releases/ubuntu22/x64/images/ubuntu/scripts/build/install-azure-devops-cli.sh
@@ -4,14 +4,6 @@
 ##  Desc:  Install Azure DevOps CLI (az devops)
 ################################################################################
 
-# Source the helpers for use with the script
-source $HELPER_SCRIPTS/etc-environment.sh
-
-# AZURE_EXTENSION_DIR shell variable defines where modules are installed
-# https://docs.microsoft.com/en-us/cli/azure/azure-cli-extensions-overview
-export AZURE_EXTENSION_DIR=/opt/az/azcliextensions
-set_etc_environment_variable "AZURE_EXTENSION_DIR" "${AZURE_EXTENSION_DIR}"
-
 # install azure devops Cli extension
 az extension add -n azure-devops
 

--- a/releases/ubuntu22/x64/images/ubuntu/scripts/build/install-gpu.sh
+++ b/releases/ubuntu22/x64/images/ubuntu/scripts/build/install-gpu.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -eo pipefail
+
+# Source the helpers for use with the script
+source $HELPER_SCRIPTS/install.sh
+
+# NVIDIA CUDA drivers
+DEBIAN_FILE="cuda-keyring_1.1-1_all.deb"
+REPO_URL="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/$DEBIAN_FILE"
+GPG_KEY="/usr/share/keyrings/cuda-archive-keyring.gpg"
+REPO_PATH="/etc/apt/sources.list.d/cuda-ubuntu2404-x86_64.list"
+
+wget $REPO_URL
+sudo dpkg -i $DEBIAN_FILE
+apt-get update
+
+package="cuda-drivers"
+version="latest"
+if [[ $version == "latest" ]]; then
+    apt-get install --no-install-recommends "$package"
+else
+    version_string=$(apt-cache madison "$package" | awk '{ print $3 }' | grep "$version" | head -1)
+    apt-get install --no-install-recommends "${package}=${version_string}"
+fi
+
+rm $DEBIAN_FILE
+rm $GPG_KEY
+rm $REPO_PATH
+
+# NVIDIA container toolkit
+REPO_URL="https://nvidia.github.io/libnvidia-container/stable/deb/\$(ARCH)"
+GPG_KEY="/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg"
+REPO_PATH="/etc/apt/sources.list.d/nvidia-container-toolkit.list"
+
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | gpg --dearmor -o $GPG_KEY
+echo "deb [signed-by=$GPG_KEY] $REPO_URL /" > $REPO_PATH
+apt-get update
+
+package="nvidia-container-toolkit"
+version="latest"
+if [[ $version == "latest" ]]; then
+    apt-get install --no-install-recommends "$package"
+else
+    version_string=$(apt-cache madison "$package" | awk '{ print $3 }' | grep "$version" | head -1)
+    apt-get install --no-install-recommends "${package}=${version_string}"
+fi
+
+# Configure the container runtime by using the nvidia-ctk command
+nvidia-ctk runtime configure --runtime=docker
+
+# Restart the Docker daemon
+systemctl restart docker
+docker info
+
+# Cleanup custom repositories
+rm $GPG_KEY
+rm $REPO_PATH

--- a/releases/ubuntu22/x64/images/ubuntu/scripts/build/install-gpu.sh
+++ b/releases/ubuntu22/x64/images/ubuntu/scripts/build/install-gpu.sh
@@ -5,11 +5,26 @@ set -eo pipefail
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/install.sh
 
+. /etc/os-release
+
+DIST_SLUG=""
+case $VERSION_CODENAME in
+    noble)
+        DIST_SLUG="ubuntu2404"
+        ;;
+    jammy)
+        DIST_SLUG="ubuntu2204"
+        ;;
+    *)
+        echo "Unsupported version codename: $VERSION_CODENAME"
+        exit 1
+        ;;
+esac
+
 # NVIDIA CUDA drivers
 DEBIAN_FILE="cuda-keyring_1.1-1_all.deb"
-REPO_URL="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/$DEBIAN_FILE"
+REPO_URL="https://developer.download.nvidia.com/compute/cuda/repos/$DIST_SLUG/x86_64/$DEBIAN_FILE"
 GPG_KEY="/usr/share/keyrings/cuda-archive-keyring.gpg"
-REPO_PATH="/etc/apt/sources.list.d/cuda-ubuntu2404-x86_64.list"
 
 wget $REPO_URL
 sudo dpkg -i $DEBIAN_FILE
@@ -26,7 +41,6 @@ fi
 
 rm $DEBIAN_FILE
 rm $GPG_KEY
-rm $REPO_PATH
 
 # NVIDIA container toolkit
 REPO_URL="https://nvidia.github.io/libnvidia-container/stable/deb/\$(ARCH)"

--- a/releases/ubuntu22/x64/images/ubuntu/scripts/build/install-zstd.sh
+++ b/releases/ubuntu22/x64/images/ubuntu/scripts/build/install-zstd.sh
@@ -22,8 +22,8 @@ use_checksum_comparison "$archive_path" "$external_hash"
 apt-get install liblz4-dev
 tar xzf "$archive_path" -C /tmp
 
-make -C "/tmp/${release_name}/contrib/pzstd" all
-make -C "/tmp/${release_name}" zstd-release
+make -C "/tmp/${release_name}/contrib/pzstd" -j $(nproc) all
+make -C "/tmp/${release_name}" -j $(nproc) zstd-release
 
 for copyprocess in zstd zstdless zstdgrep; do
     cp "/tmp/${release_name}/programs/${copyprocess}" /usr/local/bin/

--- a/releases/ubuntu22/x64/images/ubuntu/templates/ubuntu22-full-x64.pkr.hcl
+++ b/releases/ubuntu22/x64/images/ubuntu/templates/ubuntu22-full-x64.pkr.hcl
@@ -371,6 +371,12 @@ build {
   }
 
   provisioner "shell" {
+    environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}"]
+    execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    scripts          = ["${path.root}/../scripts/build/install-gpu.sh"]
+  }
+
+  provisioner "shell" {
     execute_command     = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     scripts             = ["${path.root}/../custom/files/runner-user.sh"]
   }

--- a/releases/ubuntu22/x64/images/ubuntu/toolsets/toolset-2004.json
+++ b/releases/ubuntu22/x64/images/ubuntu/toolsets/toolset-2004.json
@@ -7,7 +7,6 @@
             "platform_version": "20.04",
             "arch": "x64",
             "versions": [
-                "3.7.*",
                 "3.8.*",
                 "3.9.*",
                 "3.10.*",
@@ -269,12 +268,10 @@
     "dotnet": {
         "aptPackages": [
             "dotnet-sdk-6.0",
-            "dotnet-sdk-7.0",
             "dotnet-sdk-8.0"
         ],
         "versions": [
             "6.0",
-            "7.0",
             "8.0"
         ],
         "tools": [

--- a/releases/ubuntu22/x64/images/ubuntu/toolsets/toolset-2404.json
+++ b/releases/ubuntu22/x64/images/ubuntu/toolsets/toolset-2404.json
@@ -127,6 +127,7 @@
             "libyaml-dev",
             "libtool",
             "libssl-dev",
+            "libsqlite3-dev",
             "locales",
             "mercurial",
             "openssh-client",

--- a/releases/ubuntu24/x64/README.md
+++ b/releases/ubuntu24/x64/README.md
@@ -129,7 +129,8 @@ The `-latest` migration process is gradual and happens over 1-2 months in order 
 ### Package managers usage
 
 We use third-party package managers to install software during the image generation process. The table below lists the package managers and the software installed.
-> **Note**: third-party repositories are re-evaluated every year to identify if they are still useful and secure.
+> [!NOTE]
+> Third-party repositories are re-evaluated every year to identify if they are still useful and secure.
 
 | Operating system | Package manager                       | Third-party repos and packages |
 | :---             |        :---:                          |                           ---: |

--- a/releases/ubuntu24/x64/images/ubuntu/Ubuntu2204-Readme.md
+++ b/releases/ubuntu24/x64/images/ubuntu/Ubuntu2204-Readme.md
@@ -7,7 +7,7 @@
 # Ubuntu 22.04
 - OS Version: 22.04.5 LTS
 - Kernel Version: 6.5.0-1025-azure
-- Image Version: 20241215.1.0
+- Image Version: 20250105.1.0
 - Systemd version: 249.11-0ubuntu3.12
 
 ## Installed Software
@@ -32,16 +32,16 @@
 
 ### Package Management
 - cpan 1.64
-- Helm 3.16.3
-- Homebrew 4.4.11
-- Miniconda 24.9.2
+- Helm 3.16.4
+- Homebrew 4.4.14
+- Miniconda 24.11.1
 - Npm 10.8.2
 - NuGet 6.6.1.2
 - Pip 22.0.2
 - Pip3 22.0.2
 - Pipx 1.7.1
 - RubyGems 3.3.5
-- Vcpkg (build from commit b545373a9)
+- Vcpkg (build from commit 65be70199)
 - Yarn 1.22.22
 
 #### Environment variables
@@ -60,10 +60,10 @@ to accomplish this.
 
 ### Project Management
 - Ant 1.10.12
-- Gradle 8.11.1
+- Gradle 8.12
 - Lerna 8.1.9
 - Maven 3.8.8
-- Sbt 1.10.6
+- Sbt 1.10.7
 
 ### Tools
 - Ansible 2.17.7
@@ -73,11 +73,11 @@ to accomplish this.
 - Bazelisk 1.25.0
 - Bicep 0.32.4
 - Buildah 1.23.1
-- CMake 3.31.2
+- CMake 3.31.3
 - CodeQL Action Bundle 2.20.0
 - Docker Amazon ECR Credential Helper 0.9.0
 - Docker Compose v2 2.27.1
-- Docker-Buildx 0.19.2
+- Docker-Buildx 0.19.3
 - Docker Client 26.1.3
 - Docker Server 26.1.3
 - Fastlane 2.226.0
@@ -87,7 +87,7 @@ to accomplish this.
 - Haveged 1.9.14
 - Heroku 10.0.0
 - jq 1.6
-- Kind 0.25.0
+- Kind 0.26.0
 - Kubectl 1.32.0
 - Kustomize 5.5.0
 - Leiningen 2.11.2
@@ -99,31 +99,31 @@ to accomplish this.
 - nvm 0.40.1
 - OpenSSL 3.0.2-0ubuntu1.18
 - Packer 1.11.2
-- Parcel 2.13.2
+- Parcel 2.13.3
 - Podman 3.4.4
-- Pulumi 3.143.0
+- Pulumi 3.144.1
 - R 4.4.2
 - Skopeo 1.4.1
 - Sphinx Open Source Search Server 2.2.11
 - SVN 1.14.1
-- Terraform 1.10.2
+- Terraform 1.10.3
 - yamllint 1.35.1
 - yq 4.44.6
 - zstd 1.5.6
 
 ### CLI Tools
-- Alibaba Cloud CLI 3.0.237
-- AWS CLI 2.22.17
+- Alibaba Cloud CLI 3.0.244
+- AWS CLI 2.22.28
 - AWS CLI Session Manager Plugin 1.2.694.0
 - AWS SAM CLI 1.132.0
 - Azure CLI 2.67.0
 - Azure CLI (azure-devops) 1.0.1
-- GitHub CLI 2.63.2
-- Google Cloud CLI 503.0.0
-- Netlify CLI 17.38.0
-- OpenShift CLI 4.17.8
-- ORAS CLI 1.2.1
-- Vercel CLI 39.2.2
+- GitHub CLI 2.64.0
+- Google Cloud CLI 504.0.1
+- Netlify CLI 17.38.1
+- OpenShift CLI 4.17.10
+- ORAS CLI 1.2.2
+- Vercel CLI 39.2.5
 
 ### Java
 | Version             | Environment Variable |
@@ -142,10 +142,10 @@ Both Xdebug and PCOV extensions are installed, but only Xdebug is enabled.
 ```
 
 ### Haskell Tools
-- Cabal 3.12.1.0
-- GHC 9.10.1
-- GHCup 0.1.30.0
-- Stack 3.1.1
+- Cabal 3.14.1.1
+- GHC 9.12.1
+- GHCup 0.1.40.0
+- Stack 3.3.1
 
 ### Rust Tools
 - Cargo 1.83.0
@@ -162,13 +162,13 @@ Both Xdebug and PCOV extensions are installed, but only Xdebug is enabled.
 - Rustfmt 1.8.0
 
 ### Browsers and Drivers
-- Google Chrome 131.0.6778.139
-- ChromeDriver 131.0.6778.108
+- Google Chrome 131.0.6778.204
+- ChromeDriver 131.0.6778.204
 - Chromium 131.0.6778.0
-- Microsoft Edge 131.0.2903.99
-- Microsoft Edge WebDriver 131.0.2903.87
+- Microsoft Edge 131.0.2903.112
+- Microsoft Edge WebDriver 131.0.2903.112
 - Selenium server 4.27.0
-- Mozilla Firefox 133.0
+- Mozilla Firefox 133.0.3
 - Geckodriver 0.35.0
 
 #### Environment variables
@@ -220,10 +220,9 @@ Use the following command as a part of your job to start the service: 'sudo syst
 - 22.12.0
 
 #### Python
-- 3.7.17
 - 3.8.18
-- 3.9.20
-- 3.10.15
+- 3.9.21
+- 3.10.16
 - 3.11.11
 - 3.12.8
 
@@ -258,7 +257,7 @@ Use the following command as a part of your job to start the service: 'sudo syst
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Android Command Line Tools | 9.0                                                                                                                                                                                                                                                                                                         |
 | Android SDK Build-tools    | 35.0.0<br>34.0.0<br>33.0.0 33.0.1 33.0.2 33.0.3<br>32.0.0<br>31.0.0                                                                                                                                                                                                                                         |
-| Android SDK Platforms      | android-35-ext14 (rev 1)<br>android-35 (rev 1)<br>android-34-ext8 (rev 1)<br>android-34-ext12 (rev 1)<br>android-34-ext11 (rev 1)<br>android-34-ext10 (rev 1)<br>android-34 (rev 3)<br>android-33-ext5 (rev 1)<br>android-33-ext4 (rev 1)<br>android-33 (rev 3)<br>android-32 (rev 1)<br>android-31 (rev 1) |
+| Android SDK Platforms      | android-35-ext14 (rev 1)<br>android-35 (rev 2)<br>android-34-ext8 (rev 1)<br>android-34-ext12 (rev 1)<br>android-34-ext11 (rev 1)<br>android-34-ext10 (rev 1)<br>android-34 (rev 3)<br>android-33-ext5 (rev 1)<br>android-33-ext4 (rev 1)<br>android-33 (rev 3)<br>android-32 (rev 1)<br>android-31 (rev 1) |
 | Android Support Repository | 47.0.0                                                                                                                                                                                                                                                                                                      |
 | CMake                      | 3.10.2<br>3.18.1<br>3.22.1                                                                                                                                                                                                                                                                                  |
 | Google Play services       | 49                                                                                                                                                                                                                                                                                                          |
@@ -283,13 +282,13 @@ Use the following command as a part of your job to start the service: 'sudo syst
 | alpine:3.18          | sha256:2995c82e8e723d9a5c8585cb8e901d1c50e3c2759031027d3bff577449435157  | 2024-09-06 |
 | alpine:3.19          | sha256:7a85bf5dc56c949be827f84f9185161265c58f589bb8b2a6b6bb6d3076c1be21  | 2024-09-06 |
 | debian:10            | sha256:58ce6f1271ae1c8a2006ff7d3e54e9874d839f573d8009c20154ad0f2fb0a225  | 2024-06-13 |
-| debian:11            | sha256:e91d1b0684e0f26a29c2353c52d4814f4d153e10b1faddf9fbde473ed71e2fcf  | 2024-12-02 |
-| moby/buildkit:latest | sha256:58e6d150a3c5a4b92e99ea8df2cbe976ad6d2ae5beab39214e84fada05b059d5  | 2024-12-04 |
-| node:18              | sha256:b57ae84fe7880a23b389f8260d726b784010ed470c2ee26d4e2cbdb955d25b12  | 2024-11-15 |
+| debian:11            | sha256:21b74d95871e8676a0cf47df9caebb1021b2af60b9a6e4777ce92f92f98e3a90  | 2024-12-23 |
+| moby/buildkit:latest | sha256:86c0ad9d1137c186e9d455912167df20e530bdf7f7c19de802e892bb8ca16552  | 2024-12-16 |
+| node:18              | sha256:7f31a1eb14c61719b8bb0eaa029310cc33851f71d3578cc422b390f8096977c5  | 2024-11-15 |
 | node:18-alpine       | sha256:6eb9c3d9bd191bd2cc6ce7ec3d5ec4c2127616140c8586af96a6bec8f28689d1  | 2024-12-05 |
-| node:20              | sha256:f4755c9039bdeec5c736b2e0dd5b47700d6393b65688b9e9f807ec12f54a8690  | 2024-11-20 |
+| node:20              | sha256:d17aaa2a2fd82e09bd6a6da7cc4a79741340d2a3e39d172d1b30f295b1a850ff  | 2024-11-20 |
 | node:20-alpine       | sha256:426f843809ae05f324883afceebaa2b9cab9cb697097dbb1a2a7a41c5701de72  | 2024-12-05 |
-| node:22              | sha256:35a5dd72bcac4bce43266408b58a02be6ff0b6098ffa6f5435aeea980a8951d7  | 2024-12-03 |
+| node:22              | sha256:0e910f435308c36ea60b4cfd7b80208044d77a074d16b768a81901ce938a62dc  | 2024-12-03 |
 | node:22-alpine       | sha256:6e80991f69cc7722c561e5d14d5e72ab47c0d6b6cfb3ae50fb9cf9a7b30fdf97  | 2024-12-05 |
 | ubuntu:20.04         | sha256:8e5c4f0285ecbb4ead070431d29b576a530d3166df73ec44affc1cd27555141b  | 2024-10-11 |
 | ubuntu:22.04         | sha256:0e5e4a57c2499249aafc3b40fcd541e9a456aab7296681a3994d631587203f97  | 2024-09-11 |
@@ -306,7 +305,7 @@ Use the following command as a part of your job to start the service: 'sudo syst
 | brotli                 | 1.0.9-2build6                       |
 | bzip2                  | 1.0.8-5build1                       |
 | coreutils              | 8.32-4.1ubuntu1.2                   |
-| curl                   | 7.81.0-1ubuntu1.19                  |
+| curl                   | 7.81.0-1ubuntu1.20                  |
 | dbus                   | 1.12.20-2ubuntu4.1                  |
 | dnsutils               | 1:9.18.28-0ubuntu0.22.04.1          |
 | dpkg                   | 1.21.1ubuntu2.3                     |
@@ -329,7 +328,7 @@ Use the following command as a part of your job to start the service: 'sudo syst
 | libc++-dev             | 1:14.0-55\~exp2                     |
 | libc++abi-dev          | 1:14.0-55\~exp2                     |
 | libc6-dev              | 2.35-0ubuntu3.8                     |
-| libcurl4               | 7.81.0-1ubuntu1.19                  |
+| libcurl4               | 7.81.0-1ubuntu1.20                  |
 | libgbm-dev             | 23.2.1-1ubuntu3.1\~22.04.3          |
 | libgconf-2-4           | 3.2.6-7ubuntu2                      |
 | libgsl-dev             | 2.7.1+dfsg-3                        |

--- a/releases/ubuntu24/x64/images/ubuntu/Ubuntu2404-Readme.md
+++ b/releases/ubuntu24/x64/images/ubuntu/Ubuntu2404-Readme.md
@@ -7,7 +7,7 @@
 # Ubuntu 24.04
 - OS Version: 24.04.1 LTS
 - Kernel Version: 6.8.0-1017-azure
-- Image Version: 20241215.1.0
+- Image Version: 20250105.1.0
 - Systemd version: 255.4-1ubuntu8.4
 
 ## Installed Software
@@ -30,15 +30,15 @@
 
 ### Package Management
 - cpan 1.64
-- Helm 3.16.3
-- Homebrew 4.4.11
-- Miniconda 24.9.2
+- Helm 3.16.4
+- Homebrew 4.4.14
+- Miniconda 24.11.1
 - Npm 10.8.2
 - Pip 24.0
 - Pip3 24.0
 - Pipx 1.7.1
 - RubyGems 3.4.20
-- Vcpkg (build from commit b545373a9)
+- Vcpkg (build from commit 65be70199)
 - Yarn 1.22.22
 
 #### Environment variables
@@ -57,7 +57,7 @@ to accomplish this.
 
 ### Project Management
 - Ant 1.10.14
-- Gradle 8.11.1
+- Gradle 8.12
 - Lerna 8.1.9
 - Maven 3.8.8
 
@@ -68,11 +68,11 @@ to accomplish this.
 - Bazelisk 1.25.0
 - Bicep 0.32.4
 - Buildah 1.33.7
-- CMake 3.31.2
+- CMake 3.31.3
 - CodeQL Action Bundle 2.20.0
 - Docker Amazon ECR Credential Helper 0.9.0
 - Docker Compose v2 2.27.1
-- Docker-Buildx 0.19.2
+- Docker-Buildx 0.19.3
 - Docker Client 26.1.3
 - Docker Server 26.1.3
 - Fastlane 2.226.0
@@ -81,7 +81,7 @@ to accomplish this.
 - Git-ftp 1.6.0
 - Haveged 1.9.14
 - jq 1.7
-- Kind 0.25.0
+- Kind 0.26.0
 - Kubectl 1.32.0
 - Kustomize 5.5.0
 - MediaInfo 24.01
@@ -92,9 +92,9 @@ to accomplish this.
 - nvm 0.40.1
 - OpenSSL 3.0.13-0ubuntu3.4
 - Packer 1.11.2
-- Parcel 2.13.2
+- Parcel 2.13.3
 - Podman 4.9.3
-- Pulumi 3.143.0
+- Pulumi 3.144.1
 - Skopeo 1.13.3
 - Sphinx Open Source Search Server 2.2.11
 - yamllint 1.35.1
@@ -102,13 +102,13 @@ to accomplish this.
 - zstd 1.5.6
 
 ### CLI Tools
-- AWS CLI 2.22.17
+- AWS CLI 2.22.28
 - AWS CLI Session Manager Plugin 1.2.694.0
 - AWS SAM CLI 1.132.0
 - Azure CLI 2.67.0
 - Azure CLI (azure-devops) 1.0.1
-- GitHub CLI 2.63.2
-- Google Cloud CLI 503.0.0
+- GitHub CLI 2.64.0
+- Google Cloud CLI 504.0.1
 
 ### Java
 | Version              | Environment Variable |
@@ -127,10 +127,10 @@ Both Xdebug and PCOV extensions are installed, but only Xdebug is enabled.
 ```
 
 ### Haskell Tools
-- Cabal 3.12.1.0
-- GHC 9.10.1
-- GHCup 0.1.30.0
-- Stack 3.1.1
+- Cabal 3.14.1.1
+- GHC 9.12.1
+- GHCup 0.1.40.0
+- Stack 3.3.1
 
 ### Rust Tools
 - Cargo 1.83.0
@@ -142,13 +142,13 @@ Both Xdebug and PCOV extensions are installed, but only Xdebug is enabled.
 - Rustfmt 1.8.0
 
 ### Browsers and Drivers
-- Google Chrome 131.0.6778.139
-- ChromeDriver 131.0.6778.108
+- Google Chrome 131.0.6778.204
+- ChromeDriver 131.0.6778.204
 - Chromium 131.0.6778.0
-- Microsoft Edge 131.0.2903.99
-- Microsoft Edge WebDriver 131.0.2903.87
+- Microsoft Edge 131.0.2903.112
+- Microsoft Edge WebDriver 131.0.2903.112
 - Selenium server 4.27.0
-- Mozilla Firefox 133.0
+- Mozilla Firefox 133.0.3
 - Geckodriver 0.35.0
 
 #### Environment variables
@@ -196,8 +196,8 @@ Use the following command as a part of your job to start the service: 'sudo syst
 - 22.12.0
 
 #### Python
-- 3.9.20
-- 3.10.15
+- 3.9.21
+- 3.10.16
 - 3.11.11
 - 3.12.8
 
@@ -225,7 +225,7 @@ Use the following command as a part of your job to start the service: 'sudo syst
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Android Command Line Tools | 12.0                                                                                                                                                                                                                                      |
 | Android SDK Build-tools    | 35.0.0<br>34.0.0                                                                                                                                                                                                                          |
-| Android SDK Platforms      | android-35-ext14 (rev 1)<br>android-35 (rev 1)<br>android-34-ext8 (rev 1)<br>android-34-ext12 (rev 1)<br>android-34-ext11 (rev 1)<br>android-34-ext10 (rev 1)<br>android-34 (rev 3)<br>android-33-ext5 (rev 1)<br>android-33-ext4 (rev 1) |
+| Android SDK Platforms      | android-35-ext14 (rev 1)<br>android-35 (rev 2)<br>android-34-ext8 (rev 1)<br>android-34-ext12 (rev 1)<br>android-34-ext11 (rev 1)<br>android-34-ext10 (rev 1)<br>android-34 (rev 3)<br>android-33-ext5 (rev 1)<br>android-33-ext4 (rev 1) |
 | Android Support Repository | 47.0.0                                                                                                                                                                                                                                    |
 | Google Play services       | 49                                                                                                                                                                                                                                        |
 | Google Repository          | 58                                                                                                                                                                                                                                        |
@@ -253,7 +253,7 @@ Use the following command as a part of your job to start the service: 'sudo syst
 | brotli                 | 1.1.0-2build2               |
 | bzip2                  | 1.0.8-5.1build0.1           |
 | coreutils              | 9.4-3ubuntu6                |
-| curl                   | 8.5.0-2ubuntu10.5           |
+| curl                   | 8.5.0-2ubuntu10.6           |
 | dbus                   | 1.14.10-4ubuntu4.1          |
 | dnsutils               | 1:9.18.28-0ubuntu0.24.04.1  |
 | dpkg                   | 1.22.6ubuntu6.1             |

--- a/releases/ubuntu24/x64/images/ubuntu/scripts/build/cleanup.sh
+++ b/releases/ubuntu24/x64/images/ubuntu/scripts/build/cleanup.sh
@@ -19,6 +19,13 @@ if command -v journalctl; then
     journalctl --vacuum-time=1s
 fi
 
+# remove redundant folders from azcli
+if [[ -z "${AZURE_CONFIG_DIR}" ]]; then
+    rm -rf $AZURE_CONFIG_DIR/logs
+    rm -rf $AZURE_CONFIG_DIR/commands
+    rm -rf $AZURE_CONFIG_DIR/telemetry
+fi
+
 # delete all .gz and rotated file
 find /var/log -type f -regex ".*\.gz$" -delete
 find /var/log -type f -regex ".*\.[0-9]$" -delete

--- a/releases/ubuntu24/x64/images/ubuntu/scripts/build/install-azure-cli.sh
+++ b/releases/ubuntu24/x64/images/ubuntu/scripts/build/install-azure-cli.sh
@@ -4,12 +4,40 @@
 ##  Desc:  Install Azure CLI (az)
 ################################################################################
 
+# Source the helpers for use with the script
+source $HELPER_SCRIPTS/etc-environment.sh
+
+# AZURE_CONFIG_DIR shell variable defines where the CLI configuration file for managing behavior are stored
+# https://learn.microsoft.com/en-us/cli/azure/azure-cli-configuration#cli-configuration-file
+# This path SHOULD be different from the installation directory /opt/az/
+export AZURE_CONFIG_DIR="/opt/az-config"
+mkdir -p $AZURE_CONFIG_DIR
+set_etc_environment_variable "AZURE_CONFIG_DIR" "${AZURE_CONFIG_DIR}"
+
+# AZURE_EXTENSION_DIR shell variable defines where modules are installed
+# https://docs.microsoft.com/en-us/cli/azure/azure-cli-extensions-overview
+# This path SHOULD be different from the installation directory /opt/az/
+export AZURE_EXTENSION_DIR="/opt/az-extension"
+mkdir -p $AZURE_EXTENSION_DIR
+set_etc_environment_variable "AZURE_EXTENSION_DIR" "${AZURE_EXTENSION_DIR}"
+
 # Install Azure CLI (instructions taken from https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
 curl -fsSL https://aka.ms/InstallAzureCLIDeb | sudo bash
 
 echo "azure-cli https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt" >> $HELPER_SCRIPTS/apt-sources.txt
 
-rm -f /etc/apt/sources.list.d/azure-cli.list
-rm -f /etc/apt/sources.list.d/azure-cli.list.save
+# Remove Azure CLI repository (instructions taken from https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt#uninstall-azure-cli)
+rm -f /etc/apt/sources.list.d/azure-cli.sources
+
+echo "Warmup 'az'"
+az --help > /dev/null
+if [ $? -ne 0 ]; then
+    echo "Command 'az --help' failed"
+    exit 1
+fi
+
+# Hand over the ownership of the directories and files to the non-root user
+chown -R "$SUDO_USER:$SUDO_USER" $AZURE_CONFIG_DIR
+chown -R "$SUDO_USER:$SUDO_USER" $AZURE_EXTENSION_DIR
 
 invoke_tests "CLI.Tools" "Azure CLI"

--- a/releases/ubuntu24/x64/images/ubuntu/scripts/build/install-azure-devops-cli.sh
+++ b/releases/ubuntu24/x64/images/ubuntu/scripts/build/install-azure-devops-cli.sh
@@ -4,14 +4,6 @@
 ##  Desc:  Install Azure DevOps CLI (az devops)
 ################################################################################
 
-# Source the helpers for use with the script
-source $HELPER_SCRIPTS/etc-environment.sh
-
-# AZURE_EXTENSION_DIR shell variable defines where modules are installed
-# https://docs.microsoft.com/en-us/cli/azure/azure-cli-extensions-overview
-export AZURE_EXTENSION_DIR=/opt/az/azcliextensions
-set_etc_environment_variable "AZURE_EXTENSION_DIR" "${AZURE_EXTENSION_DIR}"
-
 # install azure devops Cli extension
 az extension add -n azure-devops
 

--- a/releases/ubuntu24/x64/images/ubuntu/scripts/build/install-gpu.sh
+++ b/releases/ubuntu24/x64/images/ubuntu/scripts/build/install-gpu.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -eo pipefail
+
+# Source the helpers for use with the script
+source $HELPER_SCRIPTS/install.sh
+
+# NVIDIA CUDA drivers
+DEBIAN_FILE="cuda-keyring_1.1-1_all.deb"
+REPO_URL="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/$DEBIAN_FILE"
+GPG_KEY="/usr/share/keyrings/cuda-archive-keyring.gpg"
+REPO_PATH="/etc/apt/sources.list.d/cuda-ubuntu2404-x86_64.list"
+
+wget $REPO_URL
+sudo dpkg -i $DEBIAN_FILE
+apt-get update
+
+package="cuda-drivers"
+version="latest"
+if [[ $version == "latest" ]]; then
+    apt-get install --no-install-recommends "$package"
+else
+    version_string=$(apt-cache madison "$package" | awk '{ print $3 }' | grep "$version" | head -1)
+    apt-get install --no-install-recommends "${package}=${version_string}"
+fi
+
+rm $DEBIAN_FILE
+rm $GPG_KEY
+rm $REPO_PATH
+
+# NVIDIA container toolkit
+REPO_URL="https://nvidia.github.io/libnvidia-container/stable/deb/\$(ARCH)"
+GPG_KEY="/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg"
+REPO_PATH="/etc/apt/sources.list.d/nvidia-container-toolkit.list"
+
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | gpg --dearmor -o $GPG_KEY
+echo "deb [signed-by=$GPG_KEY] $REPO_URL /" > $REPO_PATH
+apt-get update
+
+package="nvidia-container-toolkit"
+version="latest"
+if [[ $version == "latest" ]]; then
+    apt-get install --no-install-recommends "$package"
+else
+    version_string=$(apt-cache madison "$package" | awk '{ print $3 }' | grep "$version" | head -1)
+    apt-get install --no-install-recommends "${package}=${version_string}"
+fi
+
+# Configure the container runtime by using the nvidia-ctk command
+nvidia-ctk runtime configure --runtime=docker
+
+# Restart the Docker daemon
+systemctl restart docker
+docker info
+
+# Cleanup custom repositories
+rm $GPG_KEY
+rm $REPO_PATH

--- a/releases/ubuntu24/x64/images/ubuntu/scripts/build/install-gpu.sh
+++ b/releases/ubuntu24/x64/images/ubuntu/scripts/build/install-gpu.sh
@@ -5,11 +5,26 @@ set -eo pipefail
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/install.sh
 
+. /etc/os-release
+
+DIST_SLUG=""
+case $VERSION_CODENAME in
+    noble)
+        DIST_SLUG="ubuntu2404"
+        ;;
+    jammy)
+        DIST_SLUG="ubuntu2204"
+        ;;
+    *)
+        echo "Unsupported version codename: $VERSION_CODENAME"
+        exit 1
+        ;;
+esac
+
 # NVIDIA CUDA drivers
 DEBIAN_FILE="cuda-keyring_1.1-1_all.deb"
-REPO_URL="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/$DEBIAN_FILE"
+REPO_URL="https://developer.download.nvidia.com/compute/cuda/repos/$DIST_SLUG/x86_64/$DEBIAN_FILE"
 GPG_KEY="/usr/share/keyrings/cuda-archive-keyring.gpg"
-REPO_PATH="/etc/apt/sources.list.d/cuda-ubuntu2404-x86_64.list"
 
 wget $REPO_URL
 sudo dpkg -i $DEBIAN_FILE
@@ -26,7 +41,6 @@ fi
 
 rm $DEBIAN_FILE
 rm $GPG_KEY
-rm $REPO_PATH
 
 # NVIDIA container toolkit
 REPO_URL="https://nvidia.github.io/libnvidia-container/stable/deb/\$(ARCH)"

--- a/releases/ubuntu24/x64/images/ubuntu/scripts/build/install-zstd.sh
+++ b/releases/ubuntu24/x64/images/ubuntu/scripts/build/install-zstd.sh
@@ -22,8 +22,8 @@ use_checksum_comparison "$archive_path" "$external_hash"
 apt-get install liblz4-dev
 tar xzf "$archive_path" -C /tmp
 
-make -C "/tmp/${release_name}/contrib/pzstd" all
-make -C "/tmp/${release_name}" zstd-release
+make -C "/tmp/${release_name}/contrib/pzstd" -j $(nproc) all
+make -C "/tmp/${release_name}" -j $(nproc) zstd-release
 
 for copyprocess in zstd zstdless zstdgrep; do
     cp "/tmp/${release_name}/programs/${copyprocess}" /usr/local/bin/

--- a/releases/ubuntu24/x64/images/ubuntu/templates/ubuntu24-full-x64.pkr.hcl
+++ b/releases/ubuntu24/x64/images/ubuntu/templates/ubuntu24-full-x64.pkr.hcl
@@ -349,6 +349,12 @@ provisioner "shell" {
   }
 
   provisioner "shell" {
+    environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}"]
+    execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    scripts          = ["${path.root}/../scripts/build/install-gpu.sh"]
+  }
+
+  provisioner "shell" {
     execute_command     = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     scripts             = ["${path.root}/../custom/files/runner-user.sh"]
   }

--- a/releases/ubuntu24/x64/images/ubuntu/toolsets/toolset-2004.json
+++ b/releases/ubuntu24/x64/images/ubuntu/toolsets/toolset-2004.json
@@ -7,7 +7,6 @@
             "platform_version": "20.04",
             "arch": "x64",
             "versions": [
-                "3.7.*",
                 "3.8.*",
                 "3.9.*",
                 "3.10.*",
@@ -269,12 +268,10 @@
     "dotnet": {
         "aptPackages": [
             "dotnet-sdk-6.0",
-            "dotnet-sdk-7.0",
             "dotnet-sdk-8.0"
         ],
         "versions": [
             "6.0",
-            "7.0",
             "8.0"
         ],
         "tools": [

--- a/releases/ubuntu24/x64/images/ubuntu/toolsets/toolset-2204.json
+++ b/releases/ubuntu24/x64/images/ubuntu/toolsets/toolset-2204.json
@@ -7,7 +7,6 @@
             "platform_version": "22.04",
             "arch": "x64",
             "versions": [
-                "3.7.*",
                 "3.8.*",
                 "3.9.*",
                 "3.10.*",
@@ -268,12 +267,10 @@
     "dotnet": {
         "aptPackages": [
             "dotnet-sdk-6.0",
-            "dotnet-sdk-7.0",
             "dotnet-sdk-8.0"
         ],
         "versions": [
             "6.0",
-            "7.0",
             "8.0"
         ],
         "tools": [

--- a/releases/ubuntu24/x64/images/ubuntu/toolsets/toolset-2404.json
+++ b/releases/ubuntu24/x64/images/ubuntu/toolsets/toolset-2404.json
@@ -112,6 +112,7 @@
       "libyaml-dev",
       "libtool",
       "libssl-dev",
+      "libsqlite3-dev",
       "locales",
       "mercurial",
       "openssh-client",


### PR DESCRIPTION
Based on https://github.com/botsandus/runner-images-for-aws/pull/1 (thanks @ruffsl !)

For now I went with a simpler install script because it's easier to manage with upstream changes, but if at some point more driver versions are required, I will adjust.

Also still wondering whether I should release as separate images, or with the current `full` images. This adds a few GB more so I still need to measure the impact on boot.