### PR TITLE
fix(arm64): populate /opt/hostedtoolcache by enabling Install-Toolset.ps1

### DIFF
--- a/patches/ubuntu/templates/ubuntu22-full-arm64.pkr.hcl
+++ b/patches/ubuntu/templates/ubuntu22-full-arm64.pkr.hcl
@@ -221,7 +221,7 @@ build {
 
   provisioner "file" {
     destination = "${var.installer_script_folder}/toolset.json"
-    source      = "${path.root}/../toolsets/toolset-2204.json"
+    source      = "${path.root}/../toolsets/toolset-2204-arm64.json"
   }
 
   provisioner "shell" {
@@ -303,11 +303,11 @@ build {
     scripts          = ["${path.root}/../scripts/build/install-docker.sh"]
   }
 
-  # provisioner "shell" {
-  #   environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}"]
-  #   execute_command  = "sudo sh -c '{{ .Vars }} pwsh -f {{ .Path }}'"
-  #   scripts          = ["${path.root}/../scripts/build/Install-Toolset.ps1", "${path.root}/../scripts/build/Configure-Toolset.ps1"]
-  # }
+  provisioner "shell" {
+    environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}"]
+    execute_command  = "sudo sh -c '{{ .Vars }} pwsh -f {{ .Path }}'"
+    scripts          = ["${path.root}/../scripts/build/Install-Toolset.ps1", "${path.root}/../scripts/build/Configure-Toolset.ps1"]
+  }
 
   // provisioner "shell" {
   //   environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}"]

--- a/patches/ubuntu/templates/ubuntu24-full-arm64.pkr.hcl
+++ b/patches/ubuntu/templates/ubuntu24-full-arm64.pkr.hcl
@@ -231,7 +231,7 @@ build {
 
   provisioner "file" {
     destination = "${var.installer_script_folder}/toolset.json"
-    source      = "${path.root}/../toolsets/toolset-2404.json"
+    source      = "${path.root}/../toolsets/toolset-2404-arm64.json"
   }
 
   provisioner "shell" {
@@ -330,11 +330,11 @@ provisioner "shell" {
     scripts          = ["${path.root}/../scripts/build/install-docker.sh"]
   }
 
-  // provisioner "shell" {
-  //   environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}"]
-  //   execute_command  = "sudo sh -c '{{ .Vars }} pwsh -f {{ .Path }}'"
-  //   scripts          = ["${path.root}/../scripts/build/Install-Toolset.ps1", "${path.root}/../scripts/build/Configure-Toolset.ps1"]
-  // }
+  provisioner "shell" {
+    environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}"]
+    execute_command  = "sudo sh -c '{{ .Vars }} pwsh -f {{ .Path }}'"
+    scripts          = ["${path.root}/../scripts/build/Install-Toolset.ps1", "${path.root}/../scripts/build/Configure-Toolset.ps1"]
+  }
 
   // provisioner "shell" {
   //   environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}"]


### PR DESCRIPTION
## Summary

Fixes #49.

Both `ubuntu22-full-arm64.pkr.hcl` and `ubuntu24-full-arm64.pkr.hcl` had two issues that together left `/opt/hostedtoolcache/{node,python,go,ruby,codeql}` empty on the resulting AMIs:

1. They copied the **x64** toolset (`toolset-2204.json` / `toolset-2404.json`) as `toolset.json` instead of the arm64 variant (`toolset-2204-arm64.json` / `toolset-2404-arm64.json`, which upstream `actions/runner-images` publishes with proper arm64 declarations for these tools).
2. The `provisioner "shell" {}` block that runs `Install-Toolset.ps1` + `Configure-Toolset.ps1` was commented out (`#` in 22, `//` in 24). That script is what downloads each tool/version into `/opt/hostedtoolcache/<name>/<ver>/<arch>/`.

The corresponding `-full-x64` templates have both wired correctly, so this PR brings the arm64 templates in line.

## Diff scope

- `patches/ubuntu/templates/ubuntu22-full-arm64.pkr.hcl`: 6 lines changed
- `patches/ubuntu/templates/ubuntu24-full-arm64.pkr.hcl`: 6 lines changed
- Total: 12 insertions / 12 deletions

## Caveat / what I haven't verified

I haven't run the Packer build locally — I don't have the build pipeline set up. Please verify in CI / a test build that:

- `Install-Toolset.ps1` runs cleanly on arm64 with the new toolset (pwsh is installed earlier in both templates via `install-powershell.sh`, so the prerequisite is in place).
- All tools declared in `toolset-2*04-arm64.json` (Node, Python, Go, Ruby, CodeQL) actually have arm64 binaries in their respective versions manifests at build time. Node 22.x and 24.x linux-arm64 binaries are confirmed available (22 entries each in `actions/node-versions` manifest); the others I assume are fine since upstream uses these same toolset files for their GitHub-hosted arm64 runners.

If `Install-Toolset.ps1` was originally commented out due to a historical issue (a tool's arm64 binaries not yet existing, or pwsh load-order on arm64), that may need to be re-addressed — but the situation has likely changed since the comment was added.

## Notes for `*-stepsecurity-arm64` and `*-minimal-arm64`

Out of scope:

- `*-stepsecurity-arm64.pkr.hcl` builds on top of `*-full-arm64-*` AMIs (see `config.yml` `source_ami_name`), so it inherits this fix automatically.
- `*-minimal-arm64.pkr.hcl` intentionally doesn't run `Install-Toolset.ps1` — its toolset.json copy is for the runner package, not the toolcache. The minimal variant should remain minimal.

## Repro / impact

Documented in #49. Short version: `setup-node` on arm64 RunsOn runners has to download Node from GitHub Releases on every run because the cache is empty. When the download flakes (we observed two identical `m8g.2xlarge` instances started one second apart in the same AZ — one succeeds in 4s, the other silently aborts after 28s), the action falls through silently, downstream steps run on the preinstalled `/usr/local/bin/node` (Node 20 from `install-nodejs.sh`) instead of the requested `node-version: 24`. Step exit code 0, no surfaced error.
