### PR TITLE
Remove PackageKit from Ubuntu runner images

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,6 +142,8 @@ jobs:
         run: env | sort
       - name: Ensure apt-get update is working
         run: sudo apt-get update
+      - name: Ensure PackageKit APT hook is absent
+        run: test ! -e /etc/apt/apt.conf.d/20packagekit
       - name: Ensure code can be checked out
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Docker

--- a/patches/ubuntu/files/after-reboot.sh
+++ b/patches/ubuntu/files/after-reboot.sh
@@ -4,6 +4,11 @@ set -ex
 # Check FS on next boot for the / mount
 tune2fs -c 0 $(cat /proc/self/mounts | grep " / " | cut -f 1 -d " ")
 
+# Stopped-pool preparation masks polkit. If PackageKit remains installed, its
+# APT hook waits for a DBus activation that cannot initialize after resume.
+DEBIAN_FRONTEND=noninteractive apt-get purge -y packagekit packagekit-tools
+test ! -e /etc/apt/apt.conf.d/20packagekit
+
 rm -rf /var/lib/apt/lists
 
 cloud-init clean --logs


### PR DESCRIPTION
## Summary

- purge `packagekit` and `packagekit-tools` during Ubuntu image finalization
- fail the image build if `/etc/apt/apt.conf.d/20packagekit` remains
- assert the hook is absent in the live AMI test workflow

## Root cause

Stopped-pool preparation masks `polkit.service`. After a stopped instance resumes, PackageKit's APT hook invokes `gdbus --timeout 4`, but PackageKit cannot initialize its authority backend without polkit. This emits `Error: Timeout was reached` even though `apt-get update` exits 0.

Across two resumed-instance reproductions, 17/20 pre-fix APT updates timed out. Purging PackageKit on those same boots removed the hook and reduced the timeout rate to 0/20.

Reproduction runs:
- https://github.com/runs-on-demo/test/actions/runs/29103895847
- https://github.com/runs-on-demo/test/actions/runs/29104193013

## Validation

- Ruby test suite: 15 runs, 81 assertions, 0 failures
- `bash -n patches/ubuntu/files/after-reboot.sh`
- `actionlint .github/workflows/test.yml`
- live same-instance PackageKit purge comparison: 17/20 timeouts before, 0/20 after
