### PR TITLE
Sync supported images list in README with config.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ Those images are very close to 1-1 compatible with official GitHub Actions runne
 * `ubuntu22-full-arm64`
 * `ubuntu24-full-x64`
 * `ubuntu24-full-arm64`
+* `ubuntu26-full-x64`
+* `ubuntu26-full-arm64`
+
+Ubuntu 26 images are not yet part of the scheduled builds and are built on demand. See the notes below for Ubuntu 26 specifics.
+
+Minimal images only ship the GitHub Actions runner and Docker, for the fastest boot times:
+
+* `ubuntu24-minimal-x64`
+* `ubuntu24-minimal-arm64`
 
 ### Windows
 
@@ -31,8 +40,19 @@ Windows GPU images include the AWS GRID driver plus the CUDA toolkit.
 
 * `ubuntu22-gpu-x64`
 * `ubuntu24-gpu-x64`
-* `ubuntu24-gpu-arm64`
+* `ubuntu26-gpu-x64`
 * `windows25-gpu-x64`
+
+### StepSecurity
+
+Those are the full Ubuntu images with the [StepSecurity](https://www.stepsecurity.io/) integration preinstalled:
+
+* `ubuntu22-stepsecurity-x64`
+* `ubuntu22-stepsecurity-arm64`
+* `ubuntu24-stepsecurity-x64`
+* `ubuntu24-stepsecurity-arm64`
+* `ubuntu26-stepsecurity-x64`
+* `ubuntu26-stepsecurity-arm64`
 
 ## Supported regions
 
@@ -50,7 +70,7 @@ Windows GPU images include the AWS GRID driver plus the CUDA toolkit.
 
 ## Find the AMI
 
-For the `x86_64` image, search for:
+For any image, search for:
 
 *  name: `runs-on-v2.2-<IMAGE_ID>-*`
 *  owner: `135269210855`
@@ -108,4 +128,4 @@ Amazon Inspector EC2 scanning must be enabled in `us-east-1` for the account. Re
 
 AMI scanning is opt-in from `config.yml`. Add `inspect: true` to an image entry to scan the latest dev and prod AMIs matching `runs-on-dev-<image_id>-*` and `runs-on-v2.2-<image_id>-*`. Missing `inspect` defaults to `false`. The `inspector_scan` AMI tag is scanner-owned state; do not manage it from Packer templates or `bin/copy-ami`.
 
-See [docs/inspector-ami-scanner.md](docs/inspector-ami-scanner.md) for operational details.
+The stack template lives in [cloudformation/inspector-ami-scanner.yml](cloudformation/inspector-ami-scanner.yml).

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ Windows GPU images include the AWS GRID driver plus the CUDA toolkit.
 
 * `ubuntu22-gpu-x64`
 * `ubuntu24-gpu-x64`
-* `ubuntu26-gpu-x64`
 * `windows25-gpu-x64`
 
 ### StepSecurity
@@ -51,8 +50,6 @@ Those are the full Ubuntu images with the [StepSecurity](https://www.stepsecurit
 * `ubuntu22-stepsecurity-arm64`
 * `ubuntu24-stepsecurity-x64`
 * `ubuntu24-stepsecurity-arm64`
-* `ubuntu26-stepsecurity-x64`
-* `ubuntu26-stepsecurity-arm64`
 
 ## Supported regions
 


### PR DESCRIPTION
The supported images list in the README had drifted from what config.yml actually builds. The Ubuntu 26.04 full images were missing even though the notes section already documents their rolaunch boot behaviour, and the GPU list referenced a ubuntu24-gpu-arm64 image that has no config entry, Packer template, or build matrix wiring. This adds the Ubuntu 26 full images while noting they are currently built on demand rather than on the fifteen day schedule, removes the nonexistent arm64 GPU image, and lists the minimal and StepSecurity images that the workflows already build and publish.

It also fixes the Inspector operational details link, which pointed at docs/inspector-ami-scanner.md, a path that has never existed in the repository, and now points at the CloudFormation template instead.