### PR TITLE
Add Ubuntu 24 ARM64 and CUDA 13 GPU support

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -91,7 +91,7 @@ jobs:
       gpu: true
 
   test-gpu-blackwell:
-    if: inputs.image_id == 'ubuntu24-gpu-x64'
+    if: inputs.image_id == 'ubuntu24-gpu-x64' || inputs.image_id == 'ubuntu26-gpu-x64'
     needs:
       - build
       - test-gpu

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -33,6 +33,7 @@ jobs:
     uses: ./.github/workflows/test.yml
     with:
       ami_id: ${{ needs.build.outputs.ami_id }}
+      image_id: ${{ inputs.image_id }}
       index: 1
       platform: ${{ inputs.platform }}
       gpu: false
@@ -44,6 +45,7 @@ jobs:
     uses: ./.github/workflows/test.yml
     with:
       ami_id: ${{ needs.build.outputs.ami_id }}
+      image_id: ${{ inputs.image_id }}
       index: 2
       platform: ${{ inputs.platform }}
       gpu: false
@@ -55,6 +57,7 @@ jobs:
     uses: ./.github/workflows/test.yml
     with:
       ami_id: ${{ needs.build.outputs.ami_id }}
+      image_id: ${{ inputs.image_id }}
       index: 3
       extras: "s3-cache"
       platform: ${{ inputs.platform }}
@@ -67,6 +70,7 @@ jobs:
     uses: ./.github/workflows/test.yml
     with:
       ami_id: ${{ needs.build.outputs.ami_id }}
+      image_id: ${{ inputs.image_id }}
       index: 4
       extras: "s3-cache"
       platform: ${{ inputs.platform }}
@@ -80,8 +84,24 @@ jobs:
     uses: ./.github/workflows/test.yml
     with:
       ami_id: ${{ needs.build.outputs.ami_id }}
+      image_id: ${{ inputs.image_id }}
       index: 5
       instance_family: ${{ endsWith(inputs.image_id, '-arm64') && 'g5g' || 'g4dn' }}
+      platform: ${{ inputs.platform }}
+      gpu: true
+
+  test-gpu-blackwell:
+    if: inputs.image_id == 'ubuntu24-gpu-x64'
+    needs:
+      - build
+      - test-gpu
+    uses: ./.github/workflows/test.yml
+    with:
+      ami_id: ${{ needs.build.outputs.ami_id }}
+      image_id: ${{ inputs.image_id }}
+      index: 6
+      instance_family: g7e
+      cpu: "8"
       platform: ${{ inputs.platform }}
       gpu: true
 
@@ -90,6 +110,7 @@ jobs:
     needs:
       - build
       - test-gpu
+      - test-gpu-blackwell
     uses: ./.github/workflows/release.yml
     secrets: inherit
     with:

--- a/.github/workflows/matrix-gpu.yml
+++ b/.github/workflows/matrix-gpu.yml
@@ -11,6 +11,10 @@ on:
         type: boolean
         description: ubuntu24-gpu-x64
         default: true
+      ubuntu24_gpu_arm64:
+        type: boolean
+        description: ubuntu24-gpu-arm64
+        default: true
       ubuntu26_gpu_x64:
         type: boolean
         description: ubuntu26-gpu-x64
@@ -33,11 +37,13 @@ jobs:
         env:
           UBUNTU22_GPU_X64: ${{ github.event_name != 'workflow_dispatch' || inputs.ubuntu22_gpu_x64 }}
           UBUNTU24_GPU_X64: ${{ github.event_name != 'workflow_dispatch' || inputs.ubuntu24_gpu_x64 }}
+          UBUNTU24_GPU_ARM64: ${{ github.event_name != 'workflow_dispatch' || inputs.ubuntu24_gpu_arm64 }}
           UBUNTU26_GPU_X64: ${{ github.event_name == 'workflow_dispatch' && inputs.ubuntu26_gpu_x64 }}
         run: |
           images=()
           [ "$UBUNTU22_GPU_X64" = "true" ] && images+=("ubuntu22-gpu-x64")
           [ "$UBUNTU24_GPU_X64" = "true" ] && images+=("ubuntu24-gpu-x64")
+          [ "$UBUNTU24_GPU_ARM64" = "true" ] && images+=("ubuntu24-gpu-arm64")
           [ "$UBUNTU26_GPU_X64" = "true" ] && images+=("ubuntu26-gpu-x64")
           if [ "${#images[@]}" -eq 0 ]; then
             echo "No images selected" >&2

--- a/.github/workflows/reproductions.yml
+++ b/.github/workflows/reproductions.yml
@@ -117,7 +117,7 @@ jobs:
 
   issue-41-ubuntu24-gpu-arm64:
     name: issue 41 Ubuntu 24 GPU ARM64 on g5g
-    runs-on: runs-on=${{ github.run_id }}/runner=2cpu-linux-arm64/image=ubuntu24-gpu-arm64/family=g5g
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-arm64/image=ubuntu24-gpu-arm64/family=g5g
     steps:
       - name: Check native CUDA 13 and the open driver
         run: |
@@ -132,7 +132,7 @@ jobs:
 
   issue-46-ubuntu24-cuda13-x64:
     name: issue 46 CUDA 13 on Ubuntu 24 GPU x64
-    runs-on: runs-on=${{ github.run_id }}/runner=2cpu-linux-x64/image=ubuntu24-gpu-x64/family=g4dn
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/image=ubuntu24-gpu-x64/family=g4dn
     steps:
       - name: Check native CUDA 13
         run: |
@@ -145,7 +145,7 @@ jobs:
 
   issue-55-ubuntu24-blackwell-x64:
     name: issue 55 Ubuntu 24 open driver on Blackwell
-    runs-on: runs-on=${{ github.run_id }}/runner=2cpu-linux-x64/image=ubuntu24-gpu-x64/family=g7e
+    runs-on: runs-on=${{ github.run_id }}/runner=8cpu-linux-x64/image=ubuntu24-gpu-x64/family=g7e
     steps:
       - name: Check Blackwell with the open driver
         run: |

--- a/.github/workflows/reproductions.yml
+++ b/.github/workflows/reproductions.yml
@@ -80,6 +80,48 @@ jobs:
           apt-config dump | grep -Fx 'Acquire::http::Timeout "20";'
           apt-config dump | grep -Fx 'Acquire::https::Timeout "20";'
           sudo apt-get update -y
+
+  issue-41-ubuntu24-gpu-arm64:
+    name: issue 41 Ubuntu 24 GPU ARM64 on g5g
+    runs-on: runs-on=${{ github.run_id }}/runner=2cpu-linux-arm64/image=ubuntu24-gpu-arm64/family=g5g
+    steps:
+      - name: Check native CUDA 13 and the open driver
+        run: |
+          set -euo pipefail
+          test "$(dpkg --print-architecture)" = arm64
+          nvcc --version | grep -F "release 13.0"
+          modinfo -F license nvidia | grep -F "Dual MIT/GPL"
+          nvidia-smi
+          nvidia-smi -L
+      - name: Check CUDA 13 container access
+        run: docker run --rm --gpus all nvidia/cuda:13.0.2-base-ubuntu24.04 nvidia-smi -L
+
+  issue-46-ubuntu24-cuda13-x64:
+    name: issue 46 CUDA 13 on Ubuntu 24 GPU x64
+    runs-on: runs-on=${{ github.run_id }}/runner=2cpu-linux-x64/image=ubuntu24-gpu-x64/family=g4dn
+    steps:
+      - name: Check native CUDA 13
+        run: |
+          set -euo pipefail
+          nvcc --version | grep -F "release 13.0"
+          nvidia-smi
+          nvidia-smi -L
+      - name: Check CUDA 13 container access
+        run: docker run --rm --gpus all nvidia/cuda:13.0.2-base-ubuntu24.04 nvidia-smi -L
+
+  issue-55-ubuntu24-blackwell-x64:
+    name: issue 55 Ubuntu 24 open driver on Blackwell
+    runs-on: runs-on=${{ github.run_id }}/runner=2cpu-linux-x64/image=ubuntu24-gpu-x64/family=g7e
+    steps:
+      - name: Check Blackwell with the open driver
+        run: |
+          set -euo pipefail
+          modinfo -F license nvidia | grep -F "Dual MIT/GPL"
+          nvidia-smi --query-gpu=name --format=csv,noheader | grep -i blackwell
+          nvidia-smi -L
+      - name: Check CUDA 13 container access
+        run: docker run --rm --gpus all nvidia/cuda:13.0.2-base-ubuntu24.04 nvidia-smi -L
+
   issue-19-windows25-hyperv-vs-cpp:
     name: issue-19 windows25 Hyper-V + VS + C++
     runs-on: runs-on=${{ github.run_id }}/image=windows25-dev-x64/family=m8i

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,21 @@ on:
       ami_id:
         required: true
         type: string
+      image_id:
+        required: true
+        type: string
+      index:
+        required: false
+        type: number
+        default: 1
       instance_family:
         required: false
         type: string
         default: "m7"
+      cpu:
+        required: false
+        type: string
+        default: "2+4"
       platform:
         required: false
         type: string
@@ -28,6 +39,9 @@ on:
       ami_id:
         required: true
         type: string
+      image_id:
+        required: true
+        type: string
       index:
         required: true
         type: number
@@ -35,6 +49,10 @@ on:
         required: false
         type: string
         default: "m7"
+      cpu:
+        required: false
+        type: string
+        default: "2+4"
       platform:
         required: false
         type: string
@@ -50,7 +68,7 @@ on:
 
 jobs:
   test-windows:
-    if: ${{ inputs.platform == 'windows' }}
+    if: ${{ inputs.platform == 'windows' && !inputs.gpu }}
     name: Test${{ inputs.index || '1' }}
     runs-on: runs-on=${{ github.run_id }}-${{ inputs.index }}/env=bootstrap/volume=60g/family=${{ inputs.instance_family || 'm7' }}/cpu=2+4/ami=${{ inputs.ami_id }}/extras=${{ inputs.extras }}
     steps:
@@ -112,15 +130,8 @@ jobs:
         run: |
           dir C:\ProgramData\Amazon\EC2Launch\config
           Get-Content -Path C:\ProgramData\Amazon\EC2Launch\sysprep\unattend.xml
-      - name: Ensure NVIDIA drivers are ok
-        if: inputs.gpu
-        run: |
-          $nvidiaSmi = Get-Command nvidia-smi.exe -ErrorAction Stop
-          & $nvidiaSmi.Source
-          & $nvidiaSmi.Source -L
-
   test-linux:
-    if: ${{ inputs.platform == 'linux' }}
+    if: ${{ inputs.platform == 'linux' && !inputs.gpu }}
     name: Test${{ inputs.index || '1' }}
     runs-on: runs-on=${{ github.run_id }}-${{ inputs.index }}/env=bootstrap/family=${{ inputs.instance_family || 'm7' }}/cpu=2+4/ami=${{ inputs.ami_id }}/extras=${{ inputs.extras }}
     env:
@@ -254,12 +265,6 @@ jobs:
           echo $PATH
           rustc --version
           cargo --version
-      - name: Ensure NVIDIA drivers are ok
-        if: inputs.gpu
-        run: |
-          nvidia-smi
-          nvidia-smi -L
-          nvidia-smi -q -d Memory
       # Test for docker build and caching
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
@@ -329,6 +334,7 @@ jobs:
             echo "MD5 hash mismatch"
             exit 1
           fi
+
       - name: Save to cache (runs-on/cache)
         uses: runs-on/cache/save@a5f51d6f3fece787d03b7b4e981c82538a0654ed # v4
         with:
@@ -355,3 +361,199 @@ jobs:
             echo "MD5 hash mismatch"
             exit 1
           fi
+
+  test-gpu-windows:
+    if: ${{ inputs.gpu && inputs.platform == 'windows' }}
+    name: Test GPU ${{ inputs.image_id }} on ${{ inputs.instance_family }}
+    runs-on: runs-on=${{ github.run_id }}-${{ inputs.index }}/env=bootstrap/volume=60g/family=${{ inputs.instance_family }}/cpu=${{ inputs.cpu }}/ami=${{ inputs.ami_id }}
+    steps:
+      - name: Check NVIDIA GPU stack
+        shell: pwsh
+        env:
+          IMAGE_ID: ${{ inputs.image_id }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if ($env:IMAGE_ID -ne 'windows25-gpu-x64') {
+            throw "Unsupported GPU image ID: $env:IMAGE_ID"
+          }
+
+          $nvidiaSmi = Get-Command nvidia-smi.exe -ErrorAction Stop
+          & $nvidiaSmi.Source
+          & $nvidiaSmi.Source -L
+
+          $nvccCommand = Get-Command nvcc.exe -ErrorAction SilentlyContinue
+          $nvcc = if ($nvccCommand) {
+            $nvccCommand.Source
+          } else {
+            'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.9\bin\nvcc.exe'
+          }
+          if (-not (Test-Path $nvcc)) {
+            throw "nvcc.exe not found at $nvcc"
+          }
+          $nvccVersion = (& $nvcc --version | Out-String)
+          if ($LASTEXITCODE -ne 0 -or $nvccVersion -notmatch 'release 12\.9') {
+            throw "Expected CUDA 12.9, got: $nvccVersion"
+          }
+
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsInstallPath = (& $vswhere -latest -products * -property installationPath | Select-Object -First 1).Trim()
+          if (-not $vsInstallPath) {
+            throw 'Visual Studio installation path not found'
+          }
+          $vsDevCmd = Join-Path $vsInstallPath 'Common7\Tools\VsDevCmd.bat'
+          if (-not (Test-Path $vsDevCmd)) {
+            throw "VsDevCmd.bat not found at $vsDevCmd"
+          }
+
+          $source = Join-Path $env:RUNNER_TEMP 'cuda-smoke.cu'
+          $binary = Join-Path $env:RUNNER_TEMP 'cuda-smoke.exe'
+          @'
+          #include <cuda_runtime.h>
+
+          #include <cstdio>
+
+          __global__ void set_value(int* value) {
+            *value = 42;
+          }
+
+          int main() {
+            int* value = nullptr;
+            cudaError_t result = cudaMallocManaged(&value, sizeof(*value));
+            if (result != cudaSuccess) {
+              std::fprintf(stderr, "cudaMallocManaged failed: %s\n", cudaGetErrorString(result));
+              return 1;
+            }
+
+            set_value<<<1, 1>>>(value);
+            result = cudaGetLastError();
+            if (result == cudaSuccess) {
+              result = cudaDeviceSynchronize();
+            }
+            if (result != cudaSuccess || *value != 42) {
+              std::fprintf(stderr, "CUDA kernel failed: %s (value %d)\n", cudaGetErrorString(result), *value);
+              cudaFree(value);
+              return 1;
+            }
+
+            std::printf("CUDA kernel returned %d\n", *value);
+            cudaFree(value);
+            return 0;
+          }
+          '@ | Set-Content -Path $source -Encoding ascii
+
+          $compile = "call `"$vsDevCmd`" -arch=x64 >nul && `"$nvcc`" -arch=native `"$source`" -o `"$binary`""
+          cmd.exe /d /s /c $compile
+          if ($LASTEXITCODE -ne 0) {
+            throw "nvcc failed with exit code $LASTEXITCODE"
+          }
+          & $binary
+          if ($LASTEXITCODE -ne 0) {
+            throw "CUDA smoke test failed with exit code $LASTEXITCODE"
+          }
+
+  test-gpu-linux:
+    if: ${{ inputs.gpu && inputs.platform == 'linux' }}
+    name: Test GPU ${{ inputs.image_id }} on ${{ inputs.instance_family }}
+    runs-on: runs-on=${{ github.run_id }}-${{ inputs.index }}/env=bootstrap/family=${{ inputs.instance_family }}/cpu=${{ inputs.cpu }}/ami=${{ inputs.ami_id }}
+    steps:
+      - name: Check NVIDIA GPU stack
+        shell: bash
+        env:
+          IMAGE_ID: ${{ inputs.image_id }}
+        run: |
+          set -euo pipefail
+
+          case "$IMAGE_ID" in
+            ubuntu22-gpu-x64)
+              expected_cuda_release=12.9
+              cuda_container=nvidia/cuda:12.9.1-base-ubuntu22.04
+              expect_open_driver=false
+              ;;
+            ubuntu24-gpu-x64|ubuntu24-gpu-arm64)
+              expected_cuda_release=13.0
+              cuda_container=nvidia/cuda:13.0.2-base-ubuntu24.04
+              expect_open_driver=true
+              ;;
+            ubuntu26-gpu-x64)
+              expected_cuda_release=13.3
+              cuda_container=nvidia/cuda:13.3.1-base-ubuntu26.04
+              expect_open_driver=false
+              ;;
+            *)
+              echo "Unsupported GPU image ID: $IMAGE_ID" >&2
+              exit 1
+              ;;
+          esac
+
+          nvidia-smi
+          nvidia-smi -L
+          nvidia-smi -q -d Memory
+          nvcc --version | grep -F "release $expected_cuda_release"
+
+          if [[ "$expect_open_driver" == true ]]; then
+            modinfo -F license nvidia | grep -Fx "Dual MIT/GPL"
+          fi
+
+          cat > "$RUNNER_TEMP/cuda-smoke.cu" <<'CUDA'
+          #include <cuda_runtime.h>
+
+          #include <cstdio>
+
+          __global__ void set_value(int* value) {
+            *value = 42;
+          }
+
+          int main() {
+            int device_count = 0;
+            cudaError_t result = cudaGetDeviceCount(&device_count);
+            if (result != cudaSuccess) {
+              std::fprintf(stderr, "cudaGetDeviceCount failed: %s\n", cudaGetErrorString(result));
+              return 1;
+            }
+            if (device_count < 1) {
+              std::fprintf(stderr, "No CUDA devices found\n");
+              return 1;
+            }
+
+            cudaDeviceProp device{};
+            result = cudaGetDeviceProperties(&device, 0);
+            if (result != cudaSuccess) {
+              std::fprintf(stderr, "cudaGetDeviceProperties failed: %s\n", cudaGetErrorString(result));
+              return 1;
+            }
+
+            int* value = nullptr;
+            result = cudaMallocManaged(&value, sizeof(*value));
+            if (result != cudaSuccess) {
+              std::fprintf(stderr, "cudaMallocManaged failed: %s\n", cudaGetErrorString(result));
+              return 1;
+            }
+
+            set_value<<<1, 1>>>(value);
+            result = cudaGetLastError();
+            if (result == cudaSuccess) {
+              result = cudaDeviceSynchronize();
+            }
+            if (result != cudaSuccess) {
+              std::fprintf(stderr, "CUDA kernel failed: %s\n", cudaGetErrorString(result));
+              cudaFree(value);
+              return 1;
+            }
+            if (*value != 42) {
+              std::fprintf(stderr, "CUDA kernel returned %d instead of 42\n", *value);
+              cudaFree(value);
+              return 1;
+            }
+
+            std::printf("CUDA device: %s (compute capability %d.%d)\n", device.name, device.major, device.minor);
+            cudaFree(value);
+            return 0;
+          }
+          CUDA
+          nvcc -arch=native "$RUNNER_TEMP/cuda-smoke.cu" -o "$RUNNER_TEMP/cuda-smoke"
+          "$RUNNER_TEMP/cuda-smoke"
+
+          docker run --rm --gpus all "$cuda_container" nvidia-smi -L
+          docker run --rm --gpus all \
+            --volume "$RUNNER_TEMP/cuda-smoke:/cuda-smoke:ro" \
+            "$cuda_container" /cuda-smoke

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -477,7 +477,7 @@ jobs:
             ubuntu26-gpu-x64)
               expected_cuda_release=13.3
               cuda_container=nvidia/cuda:13.3.1-base-ubuntu26.04
-              expect_open_driver=false
+              expect_open_driver=true
               ;;
             *)
               echo "Unsupported GPU image ID: $IMAGE_ID" >&2

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Windows GPU images include the AWS GRID driver plus the CUDA toolkit.
 
 * `ubuntu22-gpu-x64`
 * `ubuntu24-gpu-x64`
+* `ubuntu24-gpu-arm64`
 * `windows25-gpu-x64`
 
 ### StepSecurity

--- a/bin/patch/lib.sh
+++ b/bin/patch/lib.sh
@@ -39,10 +39,8 @@ patch_ubuntu() {
   rolaunch_bin="$dist_dir/rolaunch-linux-$goarch"
 
   ## Script overrides
-  if [ "$ARCH" = "x64" ]; then
-    # add gpu install script
-    cp patches/ubuntu/build/install-gpu.sh "$build_dir/"
-  fi
+  # add gpu install script
+  cp patches/ubuntu/build/install-gpu.sh "$build_dir/"
   # install apt common packages in one transaction to avoid repeated apt service checks
   cp patches/ubuntu/build/install-apt-common.sh "$build_dir/"
   # restore runner install script

--- a/config.yml
+++ b/config.yml
@@ -325,6 +325,14 @@ images:
     source_ami_owner: 135269210855
     description: RunsOn Ubuntu24 GPU optimized x64
 
+  - id: ubuntu24-gpu-arm64
+    template: ubuntu-gpu-x64
+    instance_type: g5g.xlarge
+    volume_size: 40
+    source_ami_name: runs-on-dev-ubuntu24-full-arm64-*
+    source_ami_owner: 135269210855
+    description: RunsOn Ubuntu24 GPU optimized arm64
+
   - id: ubuntu24-stepsecurity-x64
     template: ubuntu-stepsecurity-x64
     instance_type: m8a.large

--- a/patches/ubuntu/build/install-gpu.sh
+++ b/patches/ubuntu/build/install-gpu.sh
@@ -9,6 +9,7 @@ DIST_SLUG=""
 NVIDIA_DRIVER_PACKAGES=""
 CUDA_PACKAGES="cuda-12-9 cuda-toolkit-12-9"
 CUDA_MAJOR_VERSION="12"
+CUDA_REPO_ARCH=""
 if is_ubuntu26; then
     DIST_SLUG="ubuntu2604"
     NVIDIA_DRIVER_PACKAGES="linux-modules-nvidia-595-aws nvidia-driver-595"
@@ -16,13 +17,21 @@ if is_ubuntu26; then
     CUDA_MAJOR_VERSION="13"
 elif is_ubuntu24; then
     DIST_SLUG="ubuntu2404"
-    NVIDIA_DRIVER_PACKAGES="linux-modules-nvidia-580-aws nvidia-driver-580"
+    NVIDIA_DRIVER_PACKAGES="linux-modules-nvidia-580-open-aws nvidia-driver-580-open"
+    CUDA_PACKAGES="cuda-toolkit-13-0"
+    CUDA_MAJOR_VERSION="13"
 elif is_ubuntu22; then
     DIST_SLUG="ubuntu2204"
     NVIDIA_DRIVER_PACKAGES="cuda-drivers-575"
 else
     echo "Unsupported ubuntu version"
     exit 1
+fi
+
+if is_arm64; then
+    CUDA_REPO_ARCH="sbsa"
+else
+    CUDA_REPO_ARCH="x86_64"
 fi
 
 set -eox pipefail
@@ -48,7 +57,7 @@ fi
 
 # NVIDIA CUDA drivers and toolkit
 DEBIAN_FILE="cuda-keyring_1.1-1_all.deb"
-REPO_URL="https://developer.download.nvidia.com/compute/cuda/repos/$DIST_SLUG/x86_64/$DEBIAN_FILE"
+REPO_URL="https://developer.download.nvidia.com/compute/cuda/repos/$DIST_SLUG/$CUDA_REPO_ARCH/$DEBIAN_FILE"
 wget $REPO_URL
 dpkg -i $DEBIAN_FILE && rm $DEBIAN_FILE
 
@@ -71,7 +80,7 @@ Pin-Priority: 1001
 EOF
 fi
 
-# Pin CUDA version to 12
+# Pin the CUDA toolkit for each Ubuntu release.
 # cuda-toolkit vs nvidia-cuda-toolkit:
 # - cuda-toolkit is NVIDIA's official package from their repository
 # - nvidia-cuda-toolkit is Ubuntu's packaged version of CUDA toolkit (often outdated version)

--- a/patches/ubuntu/build/install-gpu.sh
+++ b/patches/ubuntu/build/install-gpu.sh
@@ -12,7 +12,7 @@ CUDA_MAJOR_VERSION="12"
 CUDA_REPO_ARCH=""
 if is_ubuntu26; then
     DIST_SLUG="ubuntu2604"
-    NVIDIA_DRIVER_PACKAGES="linux-modules-nvidia-595-aws nvidia-driver-595"
+    NVIDIA_DRIVER_PACKAGES="linux-modules-nvidia-595-open-aws nvidia-driver-595-open"
     CUDA_PACKAGES="cuda-toolkit-13-3"
     CUDA_MAJOR_VERSION="13"
 elif is_ubuntu24; then

--- a/test/ubuntu_template_test.rb
+++ b/test/ubuntu_template_test.rb
@@ -19,6 +19,8 @@ class UbuntuTemplateTest < Minitest::Test
   PATCH_LIB = File.expand_path("../bin/patch/lib.sh", __dir__)
   PRE_SCRIPT = File.expand_path("../patches/ubuntu/files/pre.sh", __dir__)
   TEST_WORKFLOW = File.expand_path("../.github/workflows/test.yml", __dir__)
+  GPU_MATRIX_WORKFLOW = File.expand_path("../.github/workflows/matrix-gpu.yml", __dir__)
+  REPRODUCTIONS_WORKFLOW = File.expand_path("../.github/workflows/reproductions.yml", __dir__)
 
   def test_configure_image_data_gets_helper_scripts_env
     offenders = Dir[File.join(TEMPLATE_DIR, "*.pkr.hcl")].filter_map do |template|
@@ -135,6 +137,38 @@ class UbuntuTemplateTest < Minitest::Test
     assert_includes content, '/usr/local/cuda-${CUDA_MAJOR_VERSION}/lib64'
     assert_match(/if ! is_ubuntu26; then\s+cloud-init single --name cc_growpart\s+cloud-init single --name cc_resizefs/m, content)
     refute_includes content, "/usr/local/cuda-12/"
+  end
+
+  def test_ubuntu24_gpu_supports_x64_and_arm64_with_cuda_13
+    configured = CONFIG.fetch("images").filter_map do |image|
+      id = image.fetch("id")
+      [id, image] if id.match?(/\Aubuntu24-gpu-(?:x64|arm64)\z/)
+    end.to_h
+
+    assert_equal %w[ubuntu24-gpu-arm64 ubuntu24-gpu-x64], configured.keys.sort
+    assert_equal "g4dn.xlarge", configured.fetch("ubuntu24-gpu-x64").fetch("instance_type")
+    assert_equal "g5g.xlarge", configured.fetch("ubuntu24-gpu-arm64").fetch("instance_type")
+    assert_equal "runs-on-dev-ubuntu24-full-arm64-*", configured.fetch("ubuntu24-gpu-arm64").fetch("source_ami_name")
+
+    content = File.read(GPU_INSTALL_SCRIPT)
+    assert_includes content, 'NVIDIA_DRIVER_PACKAGES="linux-modules-nvidia-580-open-aws nvidia-driver-580-open"'
+    assert_includes content, 'CUDA_PACKAGES="cuda-toolkit-13-0"'
+    assert_match(/elif is_ubuntu24; then.*?CUDA_MAJOR_VERSION="13"/m, content)
+    assert_match(/if is_arm64; then\s+CUDA_REPO_ARCH="sbsa"\s+else\s+CUDA_REPO_ARCH="x86_64"/m, content)
+    assert_includes content, 'repos/$DIST_SLUG/$CUDA_REPO_ARCH/$DEBIAN_FILE'
+  end
+
+  def test_gpu_build_wiring_includes_ubuntu24_arm64
+    patch_lib = File.read(PATCH_LIB)
+    matrix = File.read(GPU_MATRIX_WORKFLOW)
+    reproductions = File.read(REPRODUCTIONS_WORKFLOW)
+
+    refute_match(/if \[ "\$ARCH" = "x64" \]; then\s+# add gpu install script/m, patch_lib)
+    assert_includes matrix, "ubuntu24_gpu_arm64:"
+    assert_includes matrix, 'images+=("ubuntu24-gpu-arm64")'
+    assert_includes reproductions, "issue-41-ubuntu24-gpu-arm64:"
+    assert_includes reproductions, "issue-46-ubuntu24-cuda13-x64:"
+    assert_includes reproductions, "issue-55-ubuntu24-blackwell-x64:"
   end
 
   def test_ubuntu26_descendants_clear_inherited_launch_state

--- a/test/ubuntu_template_test.rb
+++ b/test/ubuntu_template_test.rb
@@ -150,7 +150,8 @@ class UbuntuTemplateTest < Minitest::Test
 
     assert_includes content, "if is_ubuntu26; then"
     assert_includes content, 'DIST_SLUG="ubuntu2604"'
-    assert_includes content, 'linux-modules-nvidia-595-aws nvidia-driver-595'
+    assert_includes content, 'linux-modules-nvidia-595-open-aws nvidia-driver-595-open'
+    refute_includes content, 'linux-modules-nvidia-595-aws nvidia-driver-595'
     assert_includes content, 'CUDA_PACKAGES="cuda-toolkit-13-3"'
     assert_includes content, 'CUDA_MAJOR_VERSION="13"'
     assert_includes content, 'grep "release $CUDA_MAJOR_VERSION"'
@@ -208,6 +209,7 @@ class UbuntuTemplateTest < Minitest::Test
     assert_includes test_workflow, "test-gpu-windows:"
     assert_includes test_workflow, "!inputs.gpu"
     assert_includes build_test_release, "test-gpu-blackwell:"
+    assert_includes build_test_release, "inputs.image_id == 'ubuntu26-gpu-x64'"
     assert_includes build_test_release, "instance_family: g7e"
     assert_includes build_test_release, 'cpu: "8"'
     assert_match(/release:.*?needs:.*?- test-gpu-blackwell/m, build_test_release)
@@ -215,6 +217,7 @@ class UbuntuTemplateTest < Minitest::Test
     assert_includes test_workflow, "ubuntu22-gpu-x64)"
     assert_includes test_workflow, "ubuntu24-gpu-x64|ubuntu24-gpu-arm64)"
     assert_includes test_workflow, "ubuntu26-gpu-x64)"
+    assert_match(/ubuntu26-gpu-x64\).*?expect_open_driver=true/m, test_workflow)
     assert_includes test_workflow, "nvcc --version"
     assert_includes test_workflow, 'modinfo -F license nvidia | grep -Fx "Dual MIT/GPL"'
     assert_includes test_workflow, "cudaGetDeviceCount"

--- a/test/ubuntu_template_test.rb
+++ b/test/ubuntu_template_test.rb
@@ -3,6 +3,7 @@ require "yaml"
 
 class UbuntuTemplateTest < Minitest::Test
   BUILD_WORKFLOW = File.expand_path("../.github/workflows/build.yml", __dir__)
+  BUILD_TEST_RELEASE_WORKFLOW = File.expand_path("../.github/workflows/build-test-release.yml", __dir__)
   BUILD_SCRIPT = File.expand_path("../bin/build", __dir__)
   CONFIG = YAML.load_file(File.expand_path("../config.yml", __dir__))
   TEMPLATE_DIR = File.expand_path("../patches/ubuntu/templates", __dir__)
@@ -187,8 +188,44 @@ class UbuntuTemplateTest < Minitest::Test
     assert_includes matrix, "ubuntu24_gpu_arm64:"
     assert_includes matrix, 'images+=("ubuntu24-gpu-arm64")'
     assert_includes reproductions, "issue-41-ubuntu24-gpu-arm64:"
+    assert_includes reproductions, "runner=4cpu-linux-arm64/image=ubuntu24-gpu-arm64/family=g5g"
     assert_includes reproductions, "issue-46-ubuntu24-cuda13-x64:"
+    assert_includes reproductions, "runner=4cpu-linux-x64/image=ubuntu24-gpu-x64/family=g4dn"
     assert_includes reproductions, "issue-55-ubuntu24-blackwell-x64:"
+    assert_includes reproductions, "runner=8cpu-linux-x64/image=ubuntu24-gpu-x64/family=g7e"
+  end
+
+  def test_gpu_release_gate_checks_the_complete_cuda_stack
+    build_test_release = File.read(BUILD_TEST_RELEASE_WORKFLOW)
+    test_workflow = File.read(TEST_WORKFLOW)
+
+    assert_includes build_test_release, 'image_id: ${{ inputs.image_id }}'
+    assert_equal 8, build_test_release.scan('image_id: ${{ inputs.image_id }}').size
+    assert_match(/workflow_dispatch:.*?image_id:\s+required: true/m, test_workflow)
+    assert_match(/workflow_call:.*?image_id:\s+required: true/m, test_workflow)
+    assert_match(/test-gpu:.*?uses: .\/\.github\/workflows\/test\.yml.*?gpu: true/m, build_test_release)
+    assert_includes test_workflow, "test-gpu-linux:"
+    assert_includes test_workflow, "test-gpu-windows:"
+    assert_includes test_workflow, "!inputs.gpu"
+    assert_includes build_test_release, "test-gpu-blackwell:"
+    assert_includes build_test_release, "instance_family: g7e"
+    assert_includes build_test_release, 'cpu: "8"'
+    assert_match(/release:.*?needs:.*?- test-gpu-blackwell/m, build_test_release)
+    assert_includes test_workflow, 'cpu=${{ inputs.cpu }}'
+    assert_includes test_workflow, "ubuntu22-gpu-x64)"
+    assert_includes test_workflow, "ubuntu24-gpu-x64|ubuntu24-gpu-arm64)"
+    assert_includes test_workflow, "ubuntu26-gpu-x64)"
+    assert_includes test_workflow, "nvcc --version"
+    assert_includes test_workflow, 'modinfo -F license nvidia | grep -Fx "Dual MIT/GPL"'
+    assert_includes test_workflow, "cudaGetDeviceCount"
+    assert_includes test_workflow, "set_value<<<1, 1>>>(value)"
+    assert_includes test_workflow, "cudaDeviceSynchronize()"
+    assert_includes test_workflow, 'nvcc -arch=native'
+    assert_includes test_workflow, "release 12\\.9"
+    assert_includes test_workflow, "VsDevCmd.bat"
+    assert_includes test_workflow, "windows25-gpu-x64"
+    assert_includes test_workflow, 'docker run --rm --gpus all "$cuda_container" nvidia-smi -L'
+    assert_includes test_workflow, '"$cuda_container" /cuda-smoke'
   end
 
   def test_ubuntu26_descendants_clear_inherited_launch_state


### PR DESCRIPTION
## Summary

- add the `ubuntu24-gpu-arm64` image for g5g/T4G runners
- use Ubuntu prebuilt open NVIDIA modules: R580 on Ubuntu 24 and R595 on Ubuntu 26
- move Ubuntu 24 to CUDA 13.0 while keeping Ubuntu 22 and Windows 25 on CUDA 12.9
- add issue-specific T4, T4G, and Blackwell reproduction jobs with valid GPU instance sizes
- require direct GPU validation before release, including separate Blackwell gates for Ubuntu 24 and Ubuntu 26 x64

## Root cause

The GPU install script only supported NVIDIA's x86_64 repository, and Ubuntu 24 used proprietary kernel modules that cannot drive Blackwell GPUs. Its toolkit also remained pinned to CUDA 12.9. Ubuntu 26 similarly selected proprietary modules even though CUDA 13.3 supports Turing and newer GPUs and Ubuntu supplies kernel-matched R595 open AWS modules.

## Automated GPU gate

For every GPU image, the post-build workflow now checks:

- GPU discovery and memory through `nvidia-smi`
- the exact expected CUDA compiler release
- a compiled native CUDA kernel that performs real GPU work
- GPU access and the same kernel inside the matching CUDA container
- the open `Dual MIT/GPL` kernel module on Ubuntu 24 and Ubuntu 26

Ubuntu 24 and Ubuntu 26 x64 must also pass on g7e/Blackwell before release. Windows 25 remains on CUDA 12.9.1 and now compiles and runs the same native kernel through Visual Studio and `nvcc.exe`.

## Validation

- built private Ubuntu 24 x64, Ubuntu 24 ARM64, and Ubuntu 26 x64 GPU AMIs
- passed native and container CUDA tests on Ubuntu 24 with g4dn T4, g5g T4G, and g7e RTX PRO 6000 Blackwell
- passed the final-head Ubuntu 26 gate on [g4dn/T4](https://github.com/runs-on/runner-images-for-aws/actions/runs/32484773139) and [g7e/Blackwell](https://github.com/runs-on/runner-images-for-aws/actions/runs/32484781661)
- verified Ubuntu 26 driver 595.84, CUDA compiler 13.3.73, and the open `Dual MIT/GPL` kernel module
- both Ubuntu 26 GPU families ran the compiled kernel natively and in `nvidia/cuda:13.3.1-base-ubuntu26.04`
- 87 tests and 717 assertions passed
- actionlint 1.7.11, ShellCheck 0.11.0, `bash -n`, and `git diff --check` passed
- adversarial GPT-5.6 review found no substantive issues
- no generated `releases/` changes are included
- the temporary Ubuntu 26 AMI and snapshot were deleted; no GPU instances remain active in `runs-on-dev`

Closes #41
Closes #46
Closes #55
