### PR TITLE
Finalize Ubuntu runner environment paths

### DIFF
--- a/.github/workflows/reproductions.yml
+++ b/.github/workflows/reproductions.yml
@@ -80,6 +80,41 @@ jobs:
           apt-config dump | grep -Fx 'Acquire::http::Timeout "20";'
           apt-config dump | grep -Fx 'Acquire::https::Timeout "20";'
           sudo apt-get update -y
+
+  issue-31-runner-home-path-ubuntu24-full-x64:
+    name: issue 31 runner HOME paths on ubuntu24-full-x64
+    runs-on: runs-on=${{ github.run_id }}/runner=2cpu-linux-x64/image=ubuntu24-dev-x64
+    steps:
+      - name: Check runner HOME paths and tools
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          literal_home="\$HOME"
+          if grep -qF "${literal_home}" /etc/environment; then
+            echo "/etc/environment contains a literal ${literal_home}" >&2
+            exit 1
+          fi
+
+          case "${PATH}" in
+            *"${literal_home}"*) echo "PATH contains a literal ${literal_home}" >&2; exit 1 ;;
+          esac
+
+          for expected in \
+            /home/runner/.local/bin \
+            /home/runner/.cargo/bin \
+            /home/runner/.config/composer/vendor/bin \
+            /home/runner/.dotnet/tools; do
+            case ":${PATH}:" in
+              *":${expected}:"*) ;;
+              *) echo "PATH is missing ${expected}" >&2; exit 1 ;;
+            esac
+          done
+
+          command -v cargo
+          command -v rustup
+          command -v dotnet
+
   issue-19-windows25-hyperv-vs-cpp:
     name: issue-19 windows25 Hyper-V + VS + C++
     runs-on: runs-on=${{ github.run_id }}/image=windows25-dev-x64/family=m8i

--- a/patches/ubuntu/files/finalize-runner-environment.sh
+++ b/patches/ubuntu/files/finalize-runner-environment.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+runner_home="$(getent passwd runner | cut -d: -f6)"
+if [[ -z "${runner_home}" ]]; then
+  echo "Unable to resolve the runner home directory" >&2
+  exit 1
+fi
+
+sed -i "s|\$HOME|${runner_home}|g" /etc/environment
+
+if grep -qF '$HOME' /etc/environment; then
+  echo '/etc/environment still contains a literal $HOME' >&2
+  exit 1
+fi

--- a/patches/ubuntu/templates/ubuntu-full-arm64.pkr.hcl
+++ b/patches/ubuntu/templates/ubuntu-full-arm64.pkr.hcl
@@ -372,6 +372,11 @@ build {
     ]
   }
 
+  provisioner "shell" {
+    execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    scripts         = ["${path.root}/../custom/files/finalize-runner-environment.sh"]
+  }
+
   // provisioner "shell" {
   //   execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
   //   inline          = ["sleep 30", "/usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync"]

--- a/patches/ubuntu/templates/ubuntu-full-x64.pkr.hcl
+++ b/patches/ubuntu/templates/ubuntu-full-x64.pkr.hcl
@@ -373,6 +373,11 @@ build {
     ]
   }
 
+  provisioner "shell" {
+    execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    scripts         = ["${path.root}/../custom/files/finalize-runner-environment.sh"]
+  }
+
   // provisioner "shell" {
   //   execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
   //   inline          = ["sleep 30", "/usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync"]

--- a/test/ubuntu_template_test.rb
+++ b/test/ubuntu_template_test.rb
@@ -13,6 +13,7 @@ class UbuntuTemplateTest < Minitest::Test
   STEPSECURITY_ARM64_TEMPLATE = File.join(TEMPLATE_DIR, "ubuntu-stepsecurity-arm64.pkr.hcl")
   DESCENDANT_TEMPLATES = [GPU_X64_TEMPLATE, STEPSECURITY_X64_TEMPLATE, STEPSECURITY_ARM64_TEMPLATE].freeze
   FULL_ROLAUNCH_SCRIPT = File.expand_path("../patches/ubuntu/files/configure-full-rolaunch.sh", __dir__)
+  ENVIRONMENT_FINALIZER = File.expand_path("../patches/ubuntu/files/finalize-runner-environment.sh", __dir__)
   DESCENDANT_ROLAUNCH_SCRIPT = File.expand_path("../patches/ubuntu/files/finalize-rolaunch-descendant.sh", __dir__)
   GPU_INSTALL_SCRIPT = File.expand_path("../patches/ubuntu/build/install-gpu.sh", __dir__)
   MINIMAL_BASE_SCRIPT = File.expand_path("../patches/ubuntu/files/bootstrap-minimal-base.sh", __dir__)
@@ -51,6 +52,25 @@ class UbuntuTemplateTest < Minitest::Test
     assert_includes content, "https://archive.ubuntu.com/ubuntu/"
     assert_includes content, "https://security.ubuntu.com/ubuntu/"
     assert_includes content, "https://ports.ubuntu.com/ubuntu-ports/"
+  end
+
+  def test_full_images_finalize_environment_for_runner_user
+    [FULL_X64_TEMPLATE, FULL_ARM64_TEMPLATE].each do |path|
+      template = File.read(path)
+      configure_system = template.index("configure-system.sh")
+      finalize_environment = template.index("finalize-runner-environment.sh")
+
+      refute_nil configure_system, path
+      refute_nil finalize_environment, path
+      assert_operator finalize_environment, :>, configure_system, path
+    end
+  end
+
+  def test_environment_finalizer_resolves_the_runner_account_home
+    script = File.read(ENVIRONMENT_FINALIZER)
+
+    assert_includes script, "getent passwd runner"
+    assert_includes script, %(grep -qF '$HOME' /etc/environment)
   end
 
   def test_minimal_images_use_architecture_appropriate_cdn_apt_mirrors


### PR DESCRIPTION
## Summary

- replace upstream `$HOME` placeholders with the actual `runner` account home
- run the finalizer after system configuration for full Ubuntu x64 and arm64 images
- add unit and issue-specific workflow coverage

## Root cause

The upstream post-generation script assumes the last `/etc/passwd` entry is the runner user. In RunsOn full images, installing libvirt after creating `runner` leaves `libvirt-dnsmasq` last, so that script would produce `/var/lib/libvirt/dnsmasq/...` paths. The image previously skipped post-generation entirely, leaving literal `$HOME` paths instead.

This change resolves the `runner` account through `getent`, replaces the placeholders, and fails the image build if any remain.

## Validation

- 84 Ruby tests, 626 assertions
- `packer fmt -check` on both full Ubuntu templates
- `actionlint .github/workflows/reproductions.yml`
- `bash -n` and `git diff --check`
- `AMI_PUBLIC=false make build-ubuntu24-full-x64`
- exact-AMI E2E workflow: https://github.com/runs-on/test/actions/runs/32430515038

Fixes #31