### PR TITLE
Enable Ubuntu 26 StepSecurity images

### DIFF
--- a/.github/workflows/matrix-stepsecurity.yml
+++ b/.github/workflows/matrix-stepsecurity.yml
@@ -22,11 +22,11 @@ on:
       ubuntu26_stepsecurity_x64:
         type: boolean
         description: ubuntu26-stepsecurity-x64
-        default: false
+        default: true
       ubuntu26_stepsecurity_arm64:
         type: boolean
         description: ubuntu26-stepsecurity-arm64
-        default: false
+        default: true
   workflow_run:
     workflows: ['Linux images']
     branches: [main]

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Those are the full Ubuntu images with the [StepSecurity](https://www.stepsecurit
 * `ubuntu22-stepsecurity-arm64`
 * `ubuntu24-stepsecurity-x64`
 * `ubuntu24-stepsecurity-arm64`
+* `ubuntu26-stepsecurity-x64`
+* `ubuntu26-stepsecurity-arm64`
 
 ## Supported regions
 

--- a/test/ubuntu_template_test.rb
+++ b/test/ubuntu_template_test.rb
@@ -22,6 +22,8 @@ class UbuntuTemplateTest < Minitest::Test
   PRE_SCRIPT = File.expand_path("../patches/ubuntu/files/pre.sh", __dir__)
   TEST_WORKFLOW = File.expand_path("../.github/workflows/test.yml", __dir__)
   GPU_MATRIX_WORKFLOW = File.expand_path("../.github/workflows/matrix-gpu.yml", __dir__)
+  STEPSECURITY_MATRIX_WORKFLOW = File.expand_path("../.github/workflows/matrix-stepsecurity.yml", __dir__)
+  README = File.expand_path("../README.md", __dir__)
   REPRODUCTIONS_WORKFLOW = File.expand_path("../.github/workflows/reproductions.yml", __dir__)
 
   def test_configure_image_data_gets_helper_scripts_env
@@ -128,6 +130,20 @@ class UbuntuTemplateTest < Minitest::Test
     assert_equal "ubuntu-stepsecurity-x64", configured.fetch("ubuntu26-stepsecurity-x64").fetch("template")
     assert_equal "ubuntu-stepsecurity-arm64", configured.fetch("ubuntu26-stepsecurity-arm64").fetch("template")
     configured.each_value { |image| assert_equal 400, image.fetch("volume_throughput") }
+  end
+
+  def test_ubuntu26_stepsecurity_images_are_enabled_by_default
+    workflow = File.read(STEPSECURITY_MATRIX_WORKFLOW)
+    readme = File.read(README)
+
+    %w[x64 arm64].each do |architecture|
+      assert_match(
+        /^      ubuntu26_stepsecurity_#{architecture}:\n(?:        [^\n]+\n)*        default: true$/,
+        workflow
+      )
+      assert_includes workflow, %(images+=("ubuntu26-stepsecurity-#{architecture}"))
+      assert_includes readme, "`ubuntu26-stepsecurity-#{architecture}`"
+    end
   end
 
   def test_full_image_publication_can_be_disabled_without_changing_the_default


### PR DESCRIPTION
## Summary

- enable Ubuntu 26 StepSecurity x64 and arm64 images by default for manual builds
- list both images as supported
- add regression coverage for workflow selection and documentation

The external StepSecurity installer now accepts the Ubuntu 26 resolute codename and provides checksummed artifacts for both architectures.

## Validation

- bundle exec ruby -Itest -e full test loader: 88 runs, 729 assertions
- mise x actionlint@1.7.11 -- actionlint .github/workflows/matrix-stepsecurity.yml
- git diff --check origin/main...HEAD
- adversarial review: no substantive findings

A live AMI build remains delegated to the repository release workflow.