### PR TITLE
Add Ubuntu 24 GPU StepSecurity images

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -91,7 +91,7 @@ jobs:
       gpu: true
 
   test-gpu-blackwell:
-    if: inputs.image_id == 'ubuntu24-gpu-x64' || inputs.image_id == 'ubuntu26-gpu-x64'
+    if: inputs.image_id == 'ubuntu24-gpu-x64' || inputs.image_id == 'ubuntu24-gpu-stepsecurity-x64' || inputs.image_id == 'ubuntu26-gpu-x64'
     needs:
       - build
       - test-gpu

--- a/.github/workflows/matrix-gpu.yml
+++ b/.github/workflows/matrix-gpu.yml
@@ -19,6 +19,14 @@ on:
         type: boolean
         description: ubuntu26-gpu-x64
         default: false
+      ubuntu24_gpu_stepsecurity_x64:
+        type: boolean
+        description: ubuntu24-gpu-stepsecurity-x64
+        default: true
+      ubuntu24_gpu_stepsecurity_arm64:
+        type: boolean
+        description: ubuntu24-gpu-stepsecurity-arm64
+        default: false
   workflow_run:
     workflows: ['Linux images']
     branches: [main]
@@ -32,6 +40,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       image_ids: ${{ steps.select.outputs.image_ids }}
+      gpu_stepsecurity_image_ids: ${{ steps.select.outputs.gpu_stepsecurity_image_ids }}
+      has_gpu_stepsecurity_images: ${{ steps.select.outputs.has_gpu_stepsecurity_images }}
     steps:
       - id: select
         env:
@@ -39,18 +49,37 @@ jobs:
           UBUNTU24_GPU_X64: ${{ github.event_name != 'workflow_dispatch' || inputs.ubuntu24_gpu_x64 }}
           UBUNTU24_GPU_ARM64: ${{ github.event_name != 'workflow_dispatch' || inputs.ubuntu24_gpu_arm64 }}
           UBUNTU26_GPU_X64: ${{ github.event_name == 'workflow_dispatch' && inputs.ubuntu26_gpu_x64 }}
+          UBUNTU24_GPU_STEPSECURITY_X64: ${{ github.event_name != 'workflow_dispatch' || inputs.ubuntu24_gpu_stepsecurity_x64 }}
+          UBUNTU24_GPU_STEPSECURITY_ARM64: ${{ github.event_name == 'workflow_dispatch' && inputs.ubuntu24_gpu_stepsecurity_arm64 }}
         run: |
           images=()
+          gpu_stepsecurity_images=()
           [ "$UBUNTU22_GPU_X64" = "true" ] && images+=("ubuntu22-gpu-x64")
           [ "$UBUNTU24_GPU_X64" = "true" ] && images+=("ubuntu24-gpu-x64")
           [ "$UBUNTU24_GPU_ARM64" = "true" ] && images+=("ubuntu24-gpu-arm64")
           [ "$UBUNTU26_GPU_X64" = "true" ] && images+=("ubuntu26-gpu-x64")
+          if [ "$UBUNTU24_GPU_STEPSECURITY_X64" = "true" ]; then
+            images+=("ubuntu24-gpu-x64")
+            gpu_stepsecurity_images+=("ubuntu24-gpu-stepsecurity-x64")
+          fi
+          if [ "$UBUNTU24_GPU_STEPSECURITY_ARM64" = "true" ]; then
+            images+=("ubuntu24-gpu-arm64")
+            gpu_stepsecurity_images+=("ubuntu24-gpu-stepsecurity-arm64")
+          fi
           if [ "${#images[@]}" -eq 0 ]; then
             echo "No images selected" >&2
             exit 1
           fi
-          image_ids="$(printf '%s\n' "${images[@]}" | jq -R . | jq -s -c .)"
+          image_ids="$(printf '%s\n' "${images[@]}" | sort -u | jq -R . | jq -s -c .)"
           echo "image_ids=$image_ids" >> "$GITHUB_OUTPUT"
+          if [ "${#gpu_stepsecurity_images[@]}" -eq 0 ]; then
+            echo 'gpu_stepsecurity_image_ids=[]' >> "$GITHUB_OUTPUT"
+            echo 'has_gpu_stepsecurity_images=false' >> "$GITHUB_OUTPUT"
+          else
+            gpu_stepsecurity_image_ids="$(printf '%s\n' "${gpu_stepsecurity_images[@]}" | jq -R . | jq -s -c .)"
+            echo "gpu_stepsecurity_image_ids=$gpu_stepsecurity_image_ids" >> "$GITHUB_OUTPUT"
+            echo 'has_gpu_stepsecurity_images=true' >> "$GITHUB_OUTPUT"
+          fi
 
   build-test-release:
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
@@ -60,6 +89,21 @@ jobs:
       fail-fast: false
       matrix:
         image_id: ${{ fromJSON(needs.select-images.outputs.image_ids) }}
+    uses: ./.github/workflows/build-test-release.yml
+    secrets: inherit
+    with:
+      image_id: ${{ matrix.image_id }}
+
+  build-test-release-stepsecurity:
+    if: ${{ needs.select-images.outputs.has_gpu_stepsecurity_images == 'true' }}
+    name: Build/Test/Release ${{ matrix.image_id }}
+    needs:
+      - select-images
+      - build-test-release
+    strategy:
+      fail-fast: false
+      matrix:
+        image_id: ${{ fromJSON(needs.select-images.outputs.gpu_stepsecurity_image_ids) }}
     uses: ./.github/workflows/build-test-release.yml
     secrets: inherit
     with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -235,6 +235,13 @@ jobs:
         with:
           show_env: true
           metrics: memory,cpu
+      - name: Check StepSecurity installation
+        if: ${{ contains(inputs.image_id, '-stepsecurity-') }}
+        run: |
+          test -x /home/agent/agent
+          sudo systemctl cat agent.service
+          test -x /runs-on/pre.custom.sh
+          test -x /runs-on/post.custom.sh
       - name: Disk
         run: |
           sudo df -ah
@@ -469,7 +476,7 @@ jobs:
               cuda_container=nvidia/cuda:12.9.1-base-ubuntu22.04
               expect_open_driver=false
               ;;
-            ubuntu24-gpu-x64|ubuntu24-gpu-arm64)
+            ubuntu24-gpu-x64|ubuntu24-gpu-arm64|ubuntu24-gpu-stepsecurity-x64|ubuntu24-gpu-stepsecurity-arm64)
               expected_cuda_release=13.0
               cuda_container=nvidia/cuda:13.0.2-base-ubuntu24.04
               expect_open_driver=true

--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ Those are the full Ubuntu images with the [StepSecurity](https://www.stepsecurit
 * `ubuntu26-stepsecurity-x64`
 * `ubuntu26-stepsecurity-arm64`
 
+### GPU + StepSecurity
+
+Those combine the Ubuntu 24 GPU images with the StepSecurity integration:
+
+* `ubuntu24-gpu-stepsecurity-x64`
+* `ubuntu24-gpu-stepsecurity-arm64`
+
 ## Supported regions
 
 - North Virginia (`us-east-1`)

--- a/bin/utils/cleanup-amis
+++ b/bin/utils/cleanup-amis
@@ -5,6 +5,7 @@ require 'slop'
 require 'yaml'
 require 'date'
 require 'colorize'
+require_relative '../../lib/ami_name'
 
 CONFIG = YAML.load_file(File.expand_path("../../config.yml", __dir__))
 REGIONS = CONFIG.fetch("regions")
@@ -89,13 +90,13 @@ REGIONS.each_with_index do |region, index|
     ],
   })
 
-  grouped_amis = resp.images.group_by { |ami| ami.name.split('-')[3..5] }.each do |(dist, variant, arch), amis|
+  grouped_amis = resp.images.group_by { |ami| AmiName.image_id(ami.name, prefix: AMI_PREFIX) }.each do |_image_id, amis|
     amis.sort_by!(&:creation_date)
     amis.reverse!
   end
 
-  grouped_amis.each do |(dist, variant, arch), amis|
-    puts "## #{region} #{AMI_PREFIX} #{dist} #{variant} #{arch}"
+  grouped_amis.each do |image_id, amis|
+    puts "## #{region} #{AMI_PREFIX} #{image_id}"
     table = Terminal::Table.new do |t|
       t.headings = ['AMI ID', 'Created at', 'Last Launched', 'Name', 'Keep?']
       amis.each_with_index do |ami, index|
@@ -121,14 +122,14 @@ puts ""
 puts "Found #{images_to_remove.count} images to remove"
 puts ""
 
-grouped_images_to_remove = images_to_remove.group_by { |image| image.ami.name.sub(AMI_PREFIX + "-", "").split('-')[0..2] }.each do |(dist, variant, arch), images|
+grouped_images_to_remove = images_to_remove.group_by { |image| AmiName.image_id(image.ami.name, prefix: AMI_PREFIX) }.each do |_image_id, images|
   images.sort_by{|i| i.ami.creation_date}
   images.reverse!
 end
 
 table = Terminal::Table.new do |t|
   t.headings = ['Region', 'AMI ID', 'Created at', 'Last Launched', 'Name']
-  grouped_images_to_remove.each do |(dist, variant, arch), images|
+  grouped_images_to_remove.each do |_image_id, images|
     images.each do |image|
       formatted_last_launched = format_last_launched(image.ami.last_launched_time)
       t << [image.region, image.ami.image_id, image.ami.creation_date, formatted_last_launched, image.ami.name]
@@ -147,7 +148,7 @@ else
 end
 
 if reply.downcase == 'y'
-  grouped_images_to_remove.each do |(dist, variant, arch), images|
+  grouped_images_to_remove.each do |_image_id, images|
     images.each do |image|
       ec2 = Aws::EC2::Client.new(region: image.region)
 

--- a/config.yml
+++ b/config.yml
@@ -333,6 +333,22 @@ images:
     source_ami_owner: 135269210855
     description: RunsOn Ubuntu24 GPU optimized arm64
 
+  - id: ubuntu24-gpu-stepsecurity-x64
+    template: ubuntu-stepsecurity-x64
+    instance_type: g4dn.xlarge
+    volume_size: 40
+    source_ami_name: runs-on-dev-ubuntu24-gpu-x64-*
+    source_ami_owner: 135269210855
+    description: RunsOn Ubuntu24 GPU optimized + StepSecurity x64
+
+  - id: ubuntu24-gpu-stepsecurity-arm64
+    template: ubuntu-stepsecurity-arm64
+    instance_type: g5g.xlarge
+    volume_size: 40
+    source_ami_name: runs-on-dev-ubuntu24-gpu-arm64-*
+    source_ami_owner: 135269210855
+    description: RunsOn Ubuntu24 GPU optimized + StepSecurity arm64
+
   - id: ubuntu24-stepsecurity-x64
     template: ubuntu-stepsecurity-x64
     instance_type: m8a.large

--- a/lib/ami_name.rb
+++ b/lib/ami_name.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module AmiName
+  module_function
+
+  def image_id(name, prefix:)
+    expected_prefix = "#{prefix}-"
+    raise ArgumentError, "AMI name does not start with #{expected_prefix}" unless name.start_with?(expected_prefix)
+
+    components = name.delete_prefix(expected_prefix).split("-")
+    raise ArgumentError, "AMI name does not include an image ID and version" if components.length < 4
+
+    components[0...-1].join("-")
+  end
+end

--- a/test/ami_name_test.rb
+++ b/test/ami_name_test.rb
@@ -1,0 +1,26 @@
+require "minitest/autorun"
+require_relative "../lib/ami_name"
+
+class AmiNameTest < Minitest::Test
+  def test_extracts_multi_segment_image_ids
+    assert_equal(
+      "ubuntu24-gpu-stepsecurity-x64",
+      AmiName.image_id(
+        "runs-on-dev-ubuntu24-gpu-stepsecurity-x64-20260825120000",
+        prefix: "runs-on-dev"
+      )
+    )
+    assert_equal(
+      "ubuntu24-gpu-stepsecurity-arm64",
+      AmiName.image_id(
+        "runs-on-v2.2-ubuntu24-gpu-stepsecurity-arm64-20260825120000",
+        prefix: "runs-on-v2.2"
+      )
+    )
+  end
+
+  def test_rejects_unexpected_names
+    assert_raises(ArgumentError) { AmiName.image_id("other-image", prefix: "runs-on-dev") }
+    assert_raises(ArgumentError) { AmiName.image_id("runs-on-dev-ubuntu24-x64", prefix: "runs-on-dev") }
+  end
+end

--- a/test/ubuntu_template_test.rb
+++ b/test/ubuntu_template_test.rb
@@ -196,6 +196,56 @@ class UbuntuTemplateTest < Minitest::Test
     assert_includes content, 'repos/$DIST_SLUG/$CUDA_REPO_ARCH/$DEBIAN_FILE'
   end
 
+  def test_ubuntu24_gpu_stepsecurity_images_layer_on_gpu_bases
+    configured = CONFIG.fetch("images").filter_map do |image|
+      id = image.fetch("id")
+      [id, image] if id.match?(/\Aubuntu24-gpu-stepsecurity-(?:x64|arm64)\z/)
+    end.to_h
+
+    assert_equal %w[ubuntu24-gpu-stepsecurity-arm64 ubuntu24-gpu-stepsecurity-x64], configured.keys.sort
+
+    x64 = configured.fetch("ubuntu24-gpu-stepsecurity-x64")
+    assert_equal "ubuntu-stepsecurity-x64", x64.fetch("template")
+    assert_equal "g4dn.xlarge", x64.fetch("instance_type")
+    assert_equal 40, x64.fetch("volume_size")
+    assert_equal "runs-on-dev-ubuntu24-gpu-x64-*", x64.fetch("source_ami_name")
+
+    arm64 = configured.fetch("ubuntu24-gpu-stepsecurity-arm64")
+    assert_equal "ubuntu-stepsecurity-arm64", arm64.fetch("template")
+    assert_equal "g5g.xlarge", arm64.fetch("instance_type")
+    assert_equal 40, arm64.fetch("volume_size")
+    assert_equal "runs-on-dev-ubuntu24-gpu-arm64-*", arm64.fetch("source_ami_name")
+  end
+
+  def test_gpu_stepsecurity_builds_follow_their_gpu_bases
+    matrix = File.read(GPU_MATRIX_WORKFLOW)
+    build_test_release = File.read(BUILD_TEST_RELEASE_WORKFLOW)
+    test_workflow = File.read(TEST_WORKFLOW)
+    readme = File.read(README)
+
+    assert_match(
+      /^      ubuntu24_gpu_stepsecurity_x64:\n(?:        [^\n]+\n)*        default: true$/,
+      matrix
+    )
+    assert_match(
+      /^      ubuntu24_gpu_stepsecurity_arm64:\n(?:        [^\n]+\n)*        default: false$/,
+      matrix
+    )
+    assert_includes matrix, "github.event_name != 'workflow_dispatch' || inputs.ubuntu24_gpu_stepsecurity_x64"
+    assert_includes matrix, "github.event_name == 'workflow_dispatch' && inputs.ubuntu24_gpu_stepsecurity_arm64"
+    assert_includes matrix, 'images+=("ubuntu24-gpu-x64")'
+    assert_includes matrix, 'images+=("ubuntu24-gpu-arm64")'
+    assert_includes matrix, 'gpu_stepsecurity_images+=("ubuntu24-gpu-stepsecurity-x64")'
+    assert_includes matrix, 'gpu_stepsecurity_images+=("ubuntu24-gpu-stepsecurity-arm64")'
+    assert_match(/build-test-release-stepsecurity:.*?needs:.*?- build-test-release/m, matrix)
+
+    assert_includes build_test_release, "inputs.image_id == 'ubuntu24-gpu-stepsecurity-x64'"
+    assert_includes test_workflow, "ubuntu24-gpu-stepsecurity-x64|ubuntu24-gpu-stepsecurity-arm64"
+    assert_includes test_workflow, "contains(inputs.image_id, '-stepsecurity-')"
+    assert_includes readme, "`ubuntu24-gpu-stepsecurity-x64`"
+    assert_includes readme, "`ubuntu24-gpu-stepsecurity-arm64`"
+  end
+
   def test_gpu_build_wiring_includes_ubuntu24_arm64
     patch_lib = File.read(PATCH_LIB)
     matrix = File.read(GPU_MATRIX_WORKFLOW)
@@ -231,7 +281,7 @@ class UbuntuTemplateTest < Minitest::Test
     assert_match(/release:.*?needs:.*?- test-gpu-blackwell/m, build_test_release)
     assert_includes test_workflow, 'cpu=${{ inputs.cpu }}'
     assert_includes test_workflow, "ubuntu22-gpu-x64)"
-    assert_includes test_workflow, "ubuntu24-gpu-x64|ubuntu24-gpu-arm64)"
+    assert_includes test_workflow, "ubuntu24-gpu-x64|ubuntu24-gpu-arm64|ubuntu24-gpu-stepsecurity-x64|ubuntu24-gpu-stepsecurity-arm64)"
     assert_includes test_workflow, "ubuntu26-gpu-x64)"
     assert_match(/ubuntu26-gpu-x64\).*?expect_open_driver=true/m, test_workflow)
     assert_includes test_workflow, "nvcc --version"


### PR DESCRIPTION
## Summary
- add ubuntu24-gpu-stepsecurity-x64 and ubuntu24-gpu-stepsecurity-arm64
- layer StepSecurity onto the corresponding tested Ubuntu 24 GPU AMIs
- build combined images only after their GPU bases; refresh x64 automatically and keep arm64 manual
- apply CUDA, NVIDIA, Blackwell, and StepSecurity release checks
- retain complete multi-segment image IDs during AMI cleanup

## Validation
- 92 Ruby tests, 770 assertions
- Ruby syntax checks for cleanup and AMI-name helpers
- actionlint workflow validation

## Dependency
Depends on https://github.com/runs-on/runner-images-for-stepsecurity/pull/19. Merge that installer support first.